### PR TITLE
[BACKLOG-1968] Within the Data Service test windows freezes when

### DIFF
--- a/src/main/java/com/pentaho/di/trans/dataservice/ui/DataServiceTestDialog.java
+++ b/src/main/java/com/pentaho/di/trans/dataservice/ui/DataServiceTestDialog.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2002 - 2015 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -41,7 +41,6 @@ import org.pentaho.ui.xul.dom.Document;
 import org.pentaho.ui.xul.swt.SwtXulLoader;
 import org.pentaho.ui.xul.swt.SwtXulRunner;
 
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -77,6 +76,7 @@ public class DataServiceTestDialog implements  java.io.Serializable {
       return BaseMessages.getString( CLZ, key );
     }
   };
+
 
   public DataServiceTestDialog( Composite parent, DataServiceMeta dataService,
                                 TransMeta transMeta ) throws KettleException {
@@ -115,7 +115,7 @@ public class DataServiceTestDialog implements  java.io.Serializable {
 
   private void attachCallback() {
     dataServiceTestController.setCallback(
-      new DataServiceTestCallback() {
+        new DataServiceTestCallback() {
         @Override
         public void onExecuteComplete() {
           resultsView.setRowMeta( model.getResultRowMeta() );
@@ -126,17 +126,6 @@ public class DataServiceTestDialog implements  java.io.Serializable {
           if ( serviceTransLogChannel != null ) {
             serviceTransMetrics.display( MetricsUtil.getAllDurations( serviceTransLogChannel.getLogChannelId() ) );
           }
-          StringBuilder message = new StringBuilder( "Query returned " );
-          message.append( model.getResultRows().size() );
-          message.append( " rows" );
-          if ( !genTransMetrics.isEmpty() ) {
-            message.append( " in " );
-            // Get duration of first genTrans metric (should be Transformation Execution)
-            Long duration = Collections.min( genTransMetrics, DataServiceTestMetrics.METRICS_COMPARATOR ).getDuration();
-            message.append( duration );
-            message.append( " ms" );
-          }
-          model.setErrorAlertMessage( message.toString() );
         }
 
         @Override

--- a/src/main/java/com/pentaho/di/trans/dataservice/ui/model/DataServiceTestModel.java
+++ b/src/main/java/com/pentaho/di/trans/dataservice/ui/model/DataServiceTestModel.java
@@ -1,7 +1,7 @@
 /*!
  * PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+ * Copyright 2002 - 2015 Pentaho Corporation (Pentaho). All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Pentaho and its licensors. The intellectual
@@ -38,7 +38,7 @@ public class DataServiceTestModel extends XulEventSourceAdapter {
   private static final LogLevel DEFAULT_LOGLEVEL = LogLevel.DETAILED;
   private LogLevel logLevel = DEFAULT_LOGLEVEL;
 
-  private String errorAlertMessage;
+  private String alertMessage;
 
   private List<OptimizationImpactInfo> optimizationImpact = new ArrayList<OptimizationImpactInfo>();
 
@@ -50,6 +50,7 @@ public class DataServiceTestModel extends XulEventSourceAdapter {
 
   private static final int DEFAULT_MAXROWS = 100;
   private int maxRows = DEFAULT_MAXROWS;
+  private boolean executing = false;
 
   public String getSql() {
     return sql;
@@ -107,13 +108,13 @@ public class DataServiceTestModel extends XulEventSourceAdapter {
     this.maxRows = maxRows;
   }
 
-  public String getErrorAlertMessage() {
-    return errorAlertMessage;
+  public String getAlertMessage() {
+    return alertMessage;
   }
 
-  public void setErrorAlertMessage( String errorAlertMessage ) {
-    this.errorAlertMessage = errorAlertMessage;
-    firePropertyChange( "errorAlertMessage", null, errorAlertMessage );
+  public void setAlertMessage( String alertMessage ) {
+    this.alertMessage = alertMessage;
+    firePropertyChange( "alertMessage", null, alertMessage );
   }
 
   public RowMetaInterface getResultRowMeta() {
@@ -147,4 +148,12 @@ public class DataServiceTestModel extends XulEventSourceAdapter {
     return builder.toString();
   }
 
+  public boolean isExecuting() {
+    return executing;
+  }
+
+  public void setExecuting( boolean executing ) {
+    this.executing = executing;
+    firePropertyChange( "executing", null, executing );
+  }
 }

--- a/src/main/resources/com/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
+++ b/src/main/resources/com/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
@@ -1,7 +1,7 @@
 #
 #  PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
 # 
-#  Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
+#  Copyright 2002 - 2015 Pentaho Corporation (Pentaho). All rights reserved.
 # 
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Pentaho and its licensors. The intellectual
@@ -33,3 +33,4 @@ DataServiceTest.MaxRows.Label=Max Rows
 DataServiceTest.Errors.Label=There were errors, review logs.
 DataServiceTest.OptimizedQueries.Tab=Optimized Queries
 DataServiceTest.PreviewOptimization.Button=Preview Optimization
+DataServiceTest.RowsReturned.Text=Query returned {0} rows in {1}ms

--- a/src/main/resources/com/pentaho/di/trans/dataservice/ui/xul/dataservice-test-dialog.xul
+++ b/src/main/resources/com/pentaho/di/trans/dataservice/ui/xul/dataservice-test-dialog.xul
@@ -23,8 +23,8 @@
             <label  value="${DataServiceTest.MaxRows.Label}"/>
             <textbox id="maxrows-textbox" width="50" value="{default text}"/>
             <spacer flex="1"/>
-            <button  label="${DataServiceTest.PreviewOptimization.Button}" onclick="dataServiceTestController.previewQueries()" />
-            <button  label="${DataServiceTest.Execute.Button}" onclick="dataServiceTestController.executeSql()" />
+            <button id="preview-opt-btn" label="${DataServiceTest.PreviewOptimization.Button}" onclick="dataServiceTestController.previewQueries()" />
+            <button id="exec-sql-btn" label="${DataServiceTest.Execute.Button}" onclick="dataServiceTestController.executeSql()" />
         </hbox>
         <hbox align="right"  height="50">
             <label  id="error-alert" width="700" />


### PR DESCRIPTION
entering an invalid field for the where clause

This commit covers several changes to prevent non-responsiveness:
1) When executing a query, controller no longer waits for service and
gen trans to finish before returning.  Now immediately returns UI
control and polls for completion.
2) Failure of the gen trans while the service trans is still running
will result in an error message and abort the service trans.
3) Failure of the service trans will likewise result in a message and
abort.
4) Hitting the "Max Rows" limit will also stop the transformations.
Formerly the Svc trans would continue, even though no more rows would
be collected.
