### PR TITLE
[BACKLOG-2892]  Changes to allow parameter values to be honored in da…

### DIFF
--- a/src/test/java/com/pentaho/di/trans/dataservice/ui/controller/DataServiceTestControllerTest.java
+++ b/src/test/java/com/pentaho/di/trans/dataservice/ui/controller/DataServiceTestControllerTest.java
@@ -37,6 +37,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.parameters.NamedParams;
+import org.pentaho.di.core.parameters.UnknownParamException;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
@@ -50,10 +52,13 @@ import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.dom.Document;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
@@ -86,10 +91,11 @@ public class DataServiceTestControllerTest  {
   private DataServiceTestControllerTester dataServiceTestController;
 
   @Before
-  public void initMocks() {
+  public void initMocks() throws UnknownParamException {
     MockitoAnnotations.initMocks( this );
     when( dataServiceExecutor.getServiceTrans() ).thenReturn( mock( Trans.class ) );
     when( dataServiceExecutor.getGenTrans() ).thenReturn( mock( Trans.class ) );
+    when( dataServiceExecutor.getServiceTransMeta() ).thenReturn( transMeta );
     when( dataServiceExecutor.getServiceTrans().getLogChannel() ).thenReturn( mock( LogChannelInterface.class ) );
     when( dataServiceExecutor.getGenTrans().getLogChannel() ).thenReturn( mock( LogChannelInterface.class ) );
     when( dataServiceExecutor.getSql() ).thenReturn( mock( SQL.class ) );
@@ -98,17 +104,18 @@ public class DataServiceTestControllerTest  {
     when( dataServiceExecutor.getSql().getSelectFields().getFields() )
       .thenReturn( new ArrayList<SQLField>() );
 
+    when( transMeta.listParameters() ).thenReturn( new String[] { "foo", "bar" } );
+    when( transMeta.getParameterDefault( "foo" ) ).thenReturn( "fooVal" );
+    when( transMeta.getParameterDefault( "bar" ) ).thenReturn( "barVal" );
     // mocks to deal with Xul multithreading.
     when( xulDomContainer.getDocumentRoot() ).thenReturn( document );
     dataServiceTestController.setXulDomContainer( xulDomContainer );
-    doAnswer(
-      new Answer() {
-        @Override
-        public Object answer( InvocationOnMock invocationOnMock ) throws Throwable {
-          ((Runnable)invocationOnMock.getArguments()[0]).run();
-          return null;
-        }
-      } ).when( document ).invokeLater( any( Runnable.class ) );
+    doAnswer( new Answer() {
+          @Override public Object answer( InvocationOnMock invocationOnMock ) throws Throwable {
+            ( (Runnable) invocationOnMock.getArguments()[0] ).run();
+            return null;
+          }
+        } ).when( document ).invokeLater( any( Runnable.class ) );
   }
 
   @Test
@@ -116,10 +123,8 @@ public class DataServiceTestControllerTest  {
     dataServiceTestController.executeSql();
 
     InOrder inOrder = inOrder( model, dataServiceExecutor, callback );
-    inOrder.verify( model ).setServiceTransLogChannel(
-      dataServiceExecutor.getServiceTrans().getLogChannel()  );
-    inOrder.verify( model ).setGenTransLogChannel(
-      dataServiceExecutor.getGenTrans().getLogChannel() );
+    inOrder.verify( model ).setServiceTransLogChannel( dataServiceExecutor.getServiceTrans().getLogChannel() );
+    inOrder.verify( model ).setGenTransLogChannel( dataServiceExecutor.getGenTrans().getLogChannel() );
     inOrder.verify( callback ).onLogChannelUpdate();
     inOrder.verify( dataServiceExecutor ).executeQuery( any( RowListener.class ) );
   }
@@ -185,14 +190,29 @@ public class DataServiceTestControllerTest  {
     ArgumentCaptor<RowMetaInterface> argument = ArgumentCaptor.forClass( RowMetaInterface.class );
     dataServiceTestController.executeSql();
     verify( model, times( 1 ) ).setResultRowMeta( argument.capture() );
-    assertThat( argument.getValue().getFieldNames(),
-      equalTo( new String[]{"testFieldName"} ) );
+    assertThat( argument.getValue().getFieldNames(), equalTo( new String[] { "testFieldName" } ) );
   }
 
   @Test
   public void previousResultsAreClearedOnSqlExec() throws KettleException {
     dataServiceTestController.executeSql();
     verify( model, times( 1 ) ).clearResultRows();
+  }
+
+  @Test
+  public void parametersAreResetOnClose() throws KettleException {
+    // verifies that the parameter values captured when the controller
+    // is initialized are reset on close, i.e. that params set during
+    // use of the dialog do not leak.
+    dataServiceTestController.initStartingParameterValues();
+    dataServiceTestController.close();
+    ArgumentCaptor<NamedParams> paramCaptor = ArgumentCaptor.forClass( NamedParams.class );
+    verify( transMeta ).copyParametersFrom( paramCaptor.capture() );
+
+    NamedParams params = paramCaptor.getValue();
+    assertThat( Arrays.asList( params.listParameters() ), containsInAnyOrder( "foo", "bar" ) );
+    assertThat( params.getParameterDefault( "foo" ), is( "fooVal" ) );
+    assertThat( params.getParameterDefault( "bar" ), is( "barVal" ) );
   }
 
   /**
@@ -204,7 +224,7 @@ public class DataServiceTestControllerTest  {
 
     public DataServiceTestControllerTester( DataServiceTestModel model,
                                             DataServiceMeta dataService,
-                                            TransMeta transMeta ) {
+                                            TransMeta transMeta ) throws KettleException {
       super( model, dataService, transMeta );
     }
 
@@ -212,7 +232,7 @@ public class DataServiceTestControllerTest  {
                                             DataServiceMeta dataService,
                                             TransMeta transMeta,
                                             DataServiceExecutor dataServiceExecutor,
-                                            DataServiceTestCallback callback ) {
+                                            DataServiceTestCallback callback ) throws KettleException {
       super( model, dataService, transMeta );
       this.dataServiceExecutor = dataServiceExecutor;
       setCallback( callback );


### PR DESCRIPTION
…taservice SQL.

For example, "WHERE PARAMETER('foo') = 'bar'" should set the 'foo' parameter to 'bar'.
This functionality was broken at some point when a check was added for non-existent
fieldnames.  Since the parameter reference gets mapped to a FUNC_TRUE condition with
the left side equal to the key and the right side equal to value, key and value were treated
as field names.

This change yanks the left and ride-side values of FUNC_TRUE conditions after the
parameters have been extracted.  The change also includes special handling in the
DataServiceTestController to avoid leaking any modified parameters, and to reset
them in between SQL execution.
