### PR TITLE
[BACKLOG-3363]TransMeta copy for executor

### DIFF
--- a/src/main/java/com/pentaho/di/trans/dataservice/DataServiceExecutor.java
+++ b/src/main/java/com/pentaho/di/trans/dataservice/DataServiceExecutor.java
@@ -120,6 +120,8 @@ public class DataServiceExecutor {
     }
 
     public Builder serviceTrans( TransMeta serviceTransMeta ) throws KettleException {
+      // Copy TransMeta, we don't want to persist any changes to the meta during execution
+      serviceTransMeta = (TransMeta) serviceTransMeta.realClone( false );
       serviceTransMeta.setName( calculateTransname( sql, true ) );
       serviceTransMeta.activateParameters();
       return serviceTrans( new Trans( serviceTransMeta ) );


### PR DESCRIPTION
Create a defensive copy of trans meta for the data service executor.
Prevents changes (such as name) from persisting beyond execution.

@mkambol 
