### PR TITLE
[BACKLOG-3999] Test dataservices fails with NPE if transformation is invalid

### DIFF
--- a/src/main/java/com/pentaho/di/trans/dataservice/ui/DataServiceTestDialog.java
+++ b/src/main/java/com/pentaho/di/trans/dataservice/ui/DataServiceTestDialog.java
@@ -33,6 +33,7 @@ import org.pentaho.di.core.metrics.MetricsDuration;
 import org.pentaho.di.core.metrics.MetricsUtil;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.XulException;
 import org.pentaho.ui.xul.XulRunner;
@@ -46,6 +47,8 @@ import java.util.List;
 import java.util.ResourceBundle;
 
 public class DataServiceTestDialog implements  java.io.Serializable {
+  public static Class<?> PKG = DataServiceTestDialog.class;
+
   private static final String XUL_PATH = "com/pentaho/di/trans/dataservice/ui/xul/dataservice-test-dialog.xul";
   private static final String XUL_DIALOG_ID = "dataservice-test-dialog";
   private static final String GENTRANS_LOG_XUL_ID = "genTrans-log-tab";
@@ -80,7 +83,13 @@ public class DataServiceTestDialog implements  java.io.Serializable {
 
   public DataServiceTestDialog( Composite parent, DataServiceMeta dataService,
                                 TransMeta transMeta ) throws KettleException {
-    dataServiceTestController = new DataServiceTestController( model, dataService, transMeta );
+    try {
+      dataServiceTestController = new DataServiceTestController( model, dataService, transMeta );
+    } catch ( KettleException ke ) {
+      new ErrorDialog( parent.getShell(), BaseMessages.getString( PKG, "DataServiceTest.TestDataServiceError.Title" ),
+          BaseMessages.getString( PKG, "DataServiceTest.TestDataServiceError.Message" ), ke );
+      throw ke;
+    }
     xulDocument = initXul( parent );
     resultsView = initDataServiceResultsView( dataService, transMeta );
     serviceTransLogBrowser = new DataServiceTestLogBrowser( getComposite( SVCTRANS_LOG_XUL_ID ) );

--- a/src/main/java/com/pentaho/di/trans/dataservice/ui/controller/DataServiceTestController.java
+++ b/src/main/java/com/pentaho/di/trans/dataservice/ui/controller/DataServiceTestController.java
@@ -394,7 +394,9 @@ public class DataServiceTestController extends AbstractXulEventHandler {
     for ( StepMeta stepMeta :  transMeta.getSteps() ) {
       if ( stepMeta.getStepMetaInterface() instanceof TableInputMeta ) {
         DatabaseMeta dbMeta = ( (TableInputMeta) stepMeta.getStepMetaInterface() ).getDatabaseMeta();
-        dbMeta.copyVariablesFrom( transMeta );
+        if ( dbMeta != null ) {
+          dbMeta.copyVariablesFrom( transMeta );
+        }
       }
     }
     if ( startingParameterValues.listParameters().length > 0 ) {

--- a/src/main/resources/com/pentaho/di/trans/dataservice/messages/messages_en_US.properties
+++ b/src/main/resources/com/pentaho/di/trans/dataservice/messages/messages_en_US.properties
@@ -1,8 +1,8 @@
 #
 #  PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
-# 
+#
 #  Copyright 2002 - 2014 Pentaho Corporation (Pentaho). All rights reserved.
-# 
+#
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Pentaho and its licensors. The intellectual
 #  and technical concepts contained herein are proprietary and confidential

--- a/src/main/resources/com/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
+++ b/src/main/resources/com/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
@@ -1,8 +1,8 @@
 #
 #  PENTAHO CORPORATION PROPRIETARY AND CONFIDENTIAL
-# 
+#
 #  Copyright 2002 - 2015 Pentaho Corporation (Pentaho). All rights reserved.
-# 
+#
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Pentaho and its licensors. The intellectual
 #  and technical concepts contained herein are proprietary and confidential
@@ -35,6 +35,8 @@ DataServiceTest.Errors.Label=There were errors, review logs.
 DataServiceTest.OptimizedQueries.Tab=Optimized Queries
 DataServiceTest.PreviewOptimization.Button=Preview Optimization
 DataServiceTest.RowsReturned.Text=Query returned {0} rows in {1}ms
+DataServiceTest.TestDataServiceError.Title=Data service test failed
+DataServiceTest.TestDataServiceError.Message=Error occurred during data service test
 
 DataServiceDialog.Dialog.Title=Data Service
 DataServiceDialog.Menu.Label=Manage Data Services...


### PR DESCRIPTION
- Check for tableInput without databaseMeta
- Error dialog on "Test data service" dialog init
