### PR TITLE
[BACKLOG-3696]Hash TransMeta from Service

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedService.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedService.java
@@ -152,7 +152,8 @@ class CachedService implements Serializable {
       // Calculate trans meta version. If the service transformation changes, keys will no longer match
       int version;
       try {
-        version = executor.getServiceTransMeta().getXML().hashCode();
+        // Get trans meta from service instead of executor, since executor modifies the meta with every query
+        version = executor.getService().getServiceTrans().getXML().hashCode();
       } catch ( KettleException e ) {
         // Something has gone horribly wrong.
         // If data service is executing, the transformation was loaded and should be serializable

--- a/src/test/java/org/pentaho/di/trans/dataservice/optimization/cache/ServiceCacheTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/optimization/cache/ServiceCacheTest.java
@@ -95,6 +95,7 @@ public class ServiceCacheTest {
     when( dataServiceMeta.getStepname() ).thenReturn( SERVICE_STEP );
     serviceStep = serviceTrans.findRunThread( SERVICE_STEP );
     TransMeta transMeta = serviceTrans.getTransMeta();
+    when( dataServiceMeta.getServiceTrans() ).thenReturn( transMeta );
     when( transMeta.getXML() ).thenReturn( "<transformation/>" );
 
     when( factory.getExecutorService() ).thenReturn( MoreExecutors.sameThreadExecutor() );


### PR DESCRIPTION
The executor modifies the trans meta with every run by setting the name, activating parameters, etc.
Therefore when determining transMeta version for caching, use the clean copy in DataServiceMeta.

@bmorrise @mkambol 
