### PR TITLE
[CLEANUP] Use correct servlet-api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <artifactId>pentaho-metaverse-api</artifactId>
             <version>${kettle.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>pentaho</groupId>
@@ -165,7 +171,12 @@
             <version>6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
@hudak @mkambol take a look please. We're compiling with 2.3 version of servlet-api brought in by the chain pentaho-metaverse-api->pentaho-platform-core->pentaho-metadata->axis2-kernel->servlet-api:jar:2.3 and getting 3.1 version at runtime, causing LinkageError to be thrown at /kettle/listServices
