### PR TITLE
[BACKLOG-2905]  Updated behavior when the trans hasn't been saved

### DIFF
--- a/src/main/resources/org/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
@@ -64,9 +64,13 @@ DataServiceDialog.AlreadyExists.Message=The Data Service name you provided alrea
 DataServiceDelegate.DeleteDataService.Title=Delete Data Service
 DataServiceDelegate.DeleteDataService.Message=Are you sure you want to delete the [{0}] Data Service?
 DataServiceDelegate.NewTransChanged.Title=File has changed!
-DataServiceDelegate.NewTransChanged.Message=Before creating a Data Service, please save your transformation.
+DataServiceDelegate.NewTransChanged.Message=You need to save your transformation before creating a Data Service.  \nDo you want to save the transformation now?
 DataServiceDelegate.EditTransChanged.Title=File has changed!
-DataServiceDelegate.EditTransChanged.Message=Before editing your Data Service, please save your transformation.
+
+DataServiceDelegate.EditTransChanged.Message=You need to save your transformation before editing your Data Service.  \nDo you want to save the transformation now?
+DataServiceDelegate.PleaseSave.Message=Please save your transformation first!
+DataServiceDelegate.Yes.Button=Yes
+DataServiceDelegate.No.Button=No
 
 DataServiceDialog.ConnectionSetupLink.Label=Set Up Your Data Service Connection
 DataServiceDialog.ConnectionSetupLink.Url=https://help.pentaho.com/Documentation/6.0/0L0/0Y0/0H0/040


### PR DESCRIPTION
Now follows the same flow as when running a trans:  prompts to save
with a "Yes" option which will take the user directly to save.

@hudak 
