### PR TITLE
[BACKLOG-5053] Data services dialog is missing help button icon

### DIFF
--- a/src/main/resources/org/pentaho/di/trans/dataservice/ui/xul/dataservice-dialog.xul
+++ b/src/main/resources/org/pentaho/di/trans/dataservice/ui/xul/dataservice-dialog.xul
@@ -41,7 +41,7 @@
     </tabbox>
     <separator height="30"/>
     <hbox>
-        <button label="${DataServiceDialog.Help.Button}" onclick="dataServiceDialogController.showHelp()"/>
+        <button label="${DataServiceDialog.Help.Button}" image="${HelpImage.Url}" onclick="dataServiceDialogController.showHelp()"/>
         <spacer flex="1"/>
         <button id="test-dataservice-button" label="${DataServiceDialog.TestDataService.Button}" width="150"
                 onclick="dataServiceDialogController.showTestDialog()"/>


### PR DESCRIPTION
@hudak please review. Needs https://github.com/pentaho/pentaho-commons-xul/pull/89 to work
