### PR TITLE
[BACKLOG-5220]Swap 'Data Service'/Step Fields

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/optimization/paramgen/AutoParameterGenerationService.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/optimization/paramgen/AutoParameterGenerationService.java
@@ -28,18 +28,18 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.dataservice.DataServiceMeta;
 import org.pentaho.di.trans.dataservice.optimization.AutoOptimizationService;
 import org.pentaho.di.trans.dataservice.optimization.PushDownOptimizationMeta;
 import org.pentaho.di.trans.dataservice.optimization.PushDownType;
+import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.metaverse.api.ChangeType;
 import org.pentaho.metaverse.api.ILineageClient;
 import org.pentaho.metaverse.api.StepFieldOperations;
 import org.pentaho.metaverse.api.model.Operations;
-import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.logging.LogChannelInterface;
-import org.pentaho.di.trans.TransMeta;
-import org.pentaho.di.trans.step.StepMeta;
 
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -132,7 +132,7 @@ public class AutoParameterGenerationService implements AutoOptimizationService {
       for ( List<StepFieldOperations> fieldLineage : lineageSet ) {
         StepFieldOperations origin = fieldLineage.get( 0 );
         StepFieldOperations last = Iterables.getLast( fieldLineage );
-        parameterGeneration.createFieldMapping( origin.getFieldName(), last.getFieldName() );
+        parameterGeneration.createFieldMapping( last.getFieldName(), origin.getFieldName() );
       }
       optimizationList.add( pushDownOptimizationMeta );
     }

--- a/src/test/java/org/pentaho/di/trans/dataservice/optimization/paramgen/AutoParameterGenerationServiceTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/optimization/paramgen/AutoParameterGenerationServiceTest.java
@@ -28,12 +28,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.pentaho.di.trans.dataservice.DataServiceMeta;
-import org.pentaho.di.trans.dataservice.optimization.PushDownOptimizationMeta;
-import org.pentaho.di.trans.dataservice.optimization.PushDownType;
-import org.pentaho.metaverse.api.ChangeType;
-import org.pentaho.metaverse.api.ILineageClient;
-import org.pentaho.metaverse.api.StepFieldOperations;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +36,13 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.dataservice.DataServiceMeta;
+import org.pentaho.di.trans.dataservice.optimization.PushDownOptimizationMeta;
+import org.pentaho.di.trans.dataservice.optimization.PushDownType;
 import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.metaverse.api.ChangeType;
+import org.pentaho.metaverse.api.ILineageClient;
+import org.pentaho.metaverse.api.StepFieldOperations;
 
 import java.util.Collections;
 import java.util.List;
@@ -129,7 +129,7 @@ public class AutoParameterGenerationServiceTest {
       hasProperty( "type", is( parameterGeneration ) )
     ) ) );
     verify( parameterGeneration ).setParameterName( anyString() );
-    verify( parameterGeneration ).createFieldMapping( "field2_origin", "field2" );
+    verify( parameterGeneration ).createFieldMapping( "field2", "field2_origin" );
   }
 
   @Test


### PR DESCRIPTION
Columns are switched when running 'Get Optimizations', should be reversed
Only relevant when Data Service field and Step Field are different