### PR TITLE
[PDI-14537] Fix Local Data Service client

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/DataServiceContext.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/DataServiceContext.java
@@ -88,11 +88,11 @@ public class DataServiceContext {
     return this.uiFactory;
   }
 
-  public DataServiceClient getDataServiceClient() {
-    return new DataServiceClient( this );
-  }
-
   public DataServiceDelegate getDataServiceDelegate() {
     return DataServiceDelegate.withDefaultSpoonInstance( this );
+  }
+
+  public DataServiceClient createLocalClient() {
+    return getDataServiceDelegate().createClient();
   }
 }

--- a/src/main/java/org/pentaho/di/trans/dataservice/clients/DataServiceClient.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/clients/DataServiceClient.java
@@ -81,7 +81,7 @@ public class DataServiceClient implements DataServiceClientService {
           .rowLimit( maxRows )
           .build();
         executor
-          .executeQuery( byteArrayOutputStream )
+          .executeQuery( new DataOutputStream( byteArrayOutputStream ) )
           .waitUntilFinished();
       }
 

--- a/src/main/java/org/pentaho/di/trans/dataservice/clients/DataServiceClient.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/clients/DataServiceClient.java
@@ -37,7 +37,7 @@ import org.pentaho.di.trans.dataservice.DataServiceExecutor;
 import org.pentaho.di.trans.dataservice.DataServiceMeta;
 import org.pentaho.di.trans.dataservice.client.DataServiceClientService;
 import org.pentaho.di.trans.dataservice.jdbc.ThinServiceInformation;
-import org.pentaho.di.trans.dataservice.serialization.DataServiceMetaStoreUtil;
+import org.pentaho.di.trans.dataservice.serialization.DataServiceFactory;
 import org.pentaho.metastore.api.IMetaStore;
 
 import java.io.ByteArrayInputStream;
@@ -51,17 +51,14 @@ import java.text.MessageFormat;
 import java.util.List;
 
 public class DataServiceClient implements DataServiceClientService {
-  private final DataServiceMetaStoreUtil metaStoreUtil;
+  private final DataServiceFactory factory;
   private final DataServiceContext context;
-
-  private Repository repository;
-  private IMetaStore metaStore;
 
   public static final String DUMMY_TABLE_NAME = "dual";
 
-  public DataServiceClient( DataServiceContext context ) {
-    this.metaStoreUtil = context.getMetaStoreUtil();
+  public DataServiceClient( DataServiceContext context, DataServiceFactory dataServiceFactory ) {
     this.context = context;
+    this.factory = dataServiceFactory;
   }
 
   @Override public DataInputStream query( String sqlQuery, final int maxRows ) throws SQLException {
@@ -118,7 +115,7 @@ public class DataServiceClient implements DataServiceClientService {
 
   private DataServiceMeta findDataService( SQL sql ) throws KettleException {
     try {
-      return metaStoreUtil.getDataService( sql.getServiceName(), repository, metaStore );
+      return factory.getDataService( sql.getServiceName() );
     } catch ( Exception e ) {
       Throwables.propagateIfPossible( e, KettleException.class );
       throw new KettleException( "Unable to locate data service", e );
@@ -128,7 +125,7 @@ public class DataServiceClient implements DataServiceClientService {
   @Override public List<ThinServiceInformation> getServiceInformation() throws SQLException {
     List<ThinServiceInformation> services = Lists.newArrayList();
 
-    for ( DataServiceMeta service : metaStoreUtil.getDataServices( repository, metaStore, logErrors() ) ) {
+    for ( DataServiceMeta service : factory.getDataServices( logErrors() ) ) {
       TransMeta transMeta = service.getServiceTrans();
       try {
         transMeta.activateParameters();
@@ -146,15 +143,21 @@ public class DataServiceClient implements DataServiceClientService {
   }
 
   private Function<Exception, Void> logErrors() {
-    return metaStoreUtil.logErrors( "Unable to retrieve data service" );
+    return factory.logErrors( "Unable to retrieve data service" );
   }
 
+  /**
+   * @deprecated Property is unused. See {@link DataServiceClientService#setRepository(Repository)}
+   */
+  @Deprecated
   public void setRepository( Repository repository ) {
-    this.repository = repository;
   }
 
+  /**
+   * @deprecated Property is unused. See {@link DataServiceClientService#setMetaStore(IMetaStore)}
+   */
+  @Deprecated
   public void setMetaStore( IMetaStore metaStore ) {
-    this.metaStore = metaStore;
   }
 
   public FileOutputStream getDebugFileOutputStream( String filename ) throws FileNotFoundException {

--- a/src/main/java/org/pentaho/di/trans/dataservice/serialization/DataServiceFactory.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/serialization/DataServiceFactory.java
@@ -1,0 +1,80 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.serialization;
+
+import com.google.common.base.Function;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.metastore.MetaStoreConst;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.dataservice.DataServiceMeta;
+import org.pentaho.di.trans.dataservice.clients.DataServiceClient;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.pentaho.di.i18n.BaseMessages.getString;
+
+public abstract class DataServiceFactory extends DataServiceMetaStoreUtil {
+  private static final Class<?> PKG = DataServiceFactory.class;
+  protected static IMetaStore localPentahoMetaStore = openLocalPentahoMetaStore();
+
+  private static IMetaStore openLocalPentahoMetaStore() {
+    try {
+      return MetaStoreConst.openLocalPentahoMetaStore();
+    } catch ( MetaStoreException e ) {
+      LogChannel.GENERAL.logError( getString( PKG, "DataServiceFactory.LocalMetaStoreError" ), e );
+      return null;
+    }
+  }
+
+  protected DataServiceFactory( DataServiceMetaStoreUtil metaStoreUtil ) {
+    super( metaStoreUtil );
+  }
+
+  public abstract Repository getRepository();
+
+  public IMetaStore getMetaStore() {
+    Repository repository = getRepository();
+    return checkNotNull( repository != null ? repository.getMetaStore() : localPentahoMetaStore,
+      getString( PKG, "DataServiceFactory.NullMetaStore" )
+    );
+  }
+
+  public DataServiceMeta getDataService( String serviceName ) throws MetaStoreException {
+    return getDataService( serviceName, getRepository(), getMetaStore() );
+  }
+
+  public Iterable<DataServiceMeta> getDataServices( Function<Exception, Void> exceptionHandler ) {
+    return getDataServices( getRepository(), getMetaStore(), exceptionHandler );
+  }
+
+  public List<String> getDataServiceNames() throws MetaStoreException {
+    return getDataServiceNames( getMetaStore() );
+  }
+
+  public DataServiceClient createClient() {
+    return new DataServiceClient( getContext(), this );
+  }
+}

--- a/src/main/java/org/pentaho/di/trans/dataservice/serialization/DataServiceMetaStoreUtil.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/serialization/DataServiceMetaStoreUtil.java
@@ -96,6 +96,14 @@ public class DataServiceMetaStoreUtil {
     return template.createCache( name, Integer.class, String.class );
   }
 
+  public DataServiceFactory createFactory( final Supplier<Repository> repositorySupplier ) {
+    return new DataServiceFactory( this ) {
+      @Override public Repository getRepository() {
+        return repositorySupplier.get();
+      }
+    };
+  }
+
   public DataServiceMeta getDataService( String serviceName, Repository repository, IMetaStore metaStore )
     throws MetaStoreException {
     ServiceTrans transReference = getServiceTransFactory( metaStore ).loadElement( serviceName );

--- a/src/main/java/org/pentaho/di/trans/dataservice/ui/DataServiceDelegate.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/ui/DataServiceDelegate.java
@@ -31,17 +31,18 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.dataservice.DataServiceContext;
 import org.pentaho.di.trans.dataservice.DataServiceMeta;
-import org.pentaho.di.trans.dataservice.serialization.DataServiceMetaStoreUtil;
+import org.pentaho.di.trans.dataservice.serialization.DataServiceFactory;
 import org.pentaho.di.trans.dataservice.serialization.SynchronizationService;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
 import static org.pentaho.di.i18n.BaseMessages.getString;
 
-public class DataServiceDelegate extends DataServiceMetaStoreUtil {
+public class DataServiceDelegate extends DataServiceFactory {
   private static final Class<?> PKG = DataServiceDelegate.class;
   private final Supplier<Spoon> spoonSupplier;
 
@@ -144,11 +145,6 @@ public class DataServiceDelegate extends DataServiceMetaStoreUtil {
     return mb.open() == SWT.YES;
   }
 
-  public DataServiceMeta getDataService( String serviceName ) throws MetaStoreException {
-    Spoon spoon = getSpoon();
-    return getDataService( serviceName, spoon.getRepository(), spoon.getMetaStore() );
-  }
-
   @Override
   public void save( DataServiceMeta dataService ) throws MetaStoreException {
     Spoon spoon = getSpoon();
@@ -186,6 +182,10 @@ public class DataServiceDelegate extends DataServiceMetaStoreUtil {
     } catch ( KettleException e ) {
       getLogChannel().logError( "Unable to create test data service dialog", e );
     }
+  }
+
+  @Override public Repository getRepository() {
+    return getSpoon().getRepository();
   }
 
   public Spoon getSpoon() {

--- a/src/main/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceTestController.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceTestController.java
@@ -251,12 +251,7 @@ public class DataServiceTestController extends AbstractXulEventHandler {
     updateOptimizationImpact( dataServiceExec );
     updateModel( dataServiceExec );
     callback.onLogChannelUpdate();
-    try {
-      dataServiceExec.executeQuery( getDataServiceRowListener() );
-    } catch ( KettleException ke ) {
-      setErrorAlertMessage();
-      return;
-    }
+    dataServiceExec.executeQuery( getDataServiceRowListener() );
     pollForCompletion( dataServiceExec );
   }
 

--- a/src/main/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServlet.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServlet.java
@@ -62,7 +62,9 @@ public class ListDataServicesServlet extends BaseHttpServlet implements CartePlu
   private final DataServiceClient client;
 
   public ListDataServicesServlet( DataServiceContext context ) {
-    client = context.getDataServiceClient();
+    client = context.getMetaStoreUtil()
+      .createFactory( new ServletRepositoryAdapter( this ) )
+      .createClient();
   }
 
   public void doPut( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException {
@@ -85,8 +87,6 @@ public class ListDataServicesServlet extends BaseHttpServlet implements CartePlu
 
     List<ThinServiceInformation> serviceInformation = Collections.emptyList();
     try {
-      client.setRepository( transformationMap.getSlaveServerConfig().getRepository() );
-      client.setMetaStore( transformationMap.getSlaveServerConfig().getMetaStore() );
       serviceInformation = client.getServiceInformation();
     } catch ( Exception e ) {
       log.logError( "Unable to list extra repository services", e );
@@ -122,4 +122,5 @@ public class ListDataServicesServlet extends BaseHttpServlet implements CartePlu
   public void setLog( LogChannelInterface log ) {
     this.log =  log;
   }
+
 }

--- a/src/main/java/org/pentaho/di/trans/dataservice/www/ServletRepositoryAdapter.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/www/ServletRepositoryAdapter.java
@@ -1,0 +1,48 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.www;
+
+import com.google.common.base.Supplier;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.www.BaseHttpServlet;
+
+/**
+ * @author nhudak
+ */
+public class ServletRepositoryAdapter implements Supplier<Repository> {
+  private final BaseHttpServlet servlet;
+
+  public ServletRepositoryAdapter( BaseHttpServlet servlet ) {
+    this.servlet = servlet;
+  }
+
+  @Override public Repository get() {
+    try {
+      return servlet.getTransformationMap().getSlaveServerConfig().getRepository();
+    } catch ( KettleException e ) {
+      servlet.logError( "Unable to connect to repository", e );
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/pentaho/di/trans/dataservice/www/TransDataServlet.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/www/TransDataServlet.java
@@ -113,7 +113,7 @@ public class TransDataServlet extends BaseHttpServlet implements CartePluginInte
             rowLimit( maxRows ).
             build();
 
-        executor.executeQuery( response.getOutputStream() );
+        executor.executeQuery( new DataOutputStream( response.getOutputStream() ) );
 
         // For logging and tracking purposes, let's expose both the service transformation as well
         // as the generated transformation on this very carte instance

--- a/src/main/java/org/pentaho/di/trans/dataservice/www/TransDataServlet.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/www/TransDataServlet.java
@@ -67,7 +67,9 @@ public class TransDataServlet extends BaseHttpServlet implements CartePluginInte
   private final DataServiceClient client;
 
   public TransDataServlet( DataServiceContext context ) {
-    client = context.getDataServiceClient();
+    client = context.getMetaStoreUtil()
+      .createFactory( new ServletRepositoryAdapter( this ) )
+      .createClient();
   }
 
   public void doPut( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException {
@@ -103,10 +105,6 @@ public class TransDataServlet extends BaseHttpServlet implements CartePluginInte
         // Support for SELECT 1 and SELECT 1 FROM dual
         client.writeDummyRow( sql, new DataOutputStream( response.getOutputStream() ) );
       } else {
-        // Update client with configured repository and metastore
-        client.setRepository( transformationMap.getSlaveServerConfig().getRepository() );
-        client.setMetaStore( transformationMap.getSlaveServerConfig().getMetaStore() );
-
         // Pass query to client
         DataServiceExecutor executor = client.buildExecutor( sql ).
             parameters( parameters ).

--- a/src/main/resources/OSGI-INF/blueprint/services.xml
+++ b/src/main/resources/OSGI-INF/blueprint/services.xml
@@ -12,7 +12,7 @@
              interface="java.util.concurrent.ExecutorService">
     </service>
 
-    <bean id="uiFactory" class="org.pentaho.di.trans.dataservice.ui.UIFactory" scope="singleton"></bean>
+    <bean id="uiFactory" class="org.pentaho.di.trans.dataservice.ui.UIFactory" scope="singleton"/>
 
     <bean id="context" class="org.pentaho.di.trans.dataservice.DataServiceContext" scope="singleton">
         <argument ref="pushDownFactories"/>
@@ -36,9 +36,7 @@
 
     <!-- Local Client Service -->
     <service id="dataServiceClientService" interface="org.pentaho.di.trans.dataservice.client.DataServiceClientService">
-        <bean class="org.pentaho.di.trans.dataservice.clients.DataServiceClient">
-            <argument ref="context"/>
-        </bean>
+        <bean factory-ref="context" factory-method="createLocalClient"/>
     </service>
     <!-- /Local Client Service -->
 

--- a/src/main/resources/org/pentaho/di/trans/dataservice/serialization/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/dataservice/serialization/messages/messages_en_US.properties
@@ -28,3 +28,6 @@ Messages.SaveError.StepMissing=Data Service does not have a step specified
 Messages.SaveError.StepNotFound=Step "{0}" could not be found on the transformation
 Messages.SaveError.NameConflict=Data Service "{0}" already exists
 Messages.SaveError.StepConflict=Step "{0}" is already used by "{1}"
+
+DataServiceFactory.LocalMetaStoreError=Unable to open local Meta Store
+DataServiceFactory.NullMetaStore=Unable to connect to Meta Store

--- a/src/test/java/org/pentaho/di/trans/dataservice/BaseTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/BaseTest.java
@@ -23,11 +23,13 @@
 package org.pentaho.di.trans.dataservice;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.caching.api.Constants;
@@ -36,11 +38,13 @@ import org.pentaho.caching.api.PentahoCacheTemplateConfiguration;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.sql.SQL;
+import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.StringObjectId;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.dataservice.clients.DataServiceClient;
 import org.pentaho.di.trans.dataservice.optimization.AutoOptimizationService;
 import org.pentaho.di.trans.dataservice.optimization.PushDownFactory;
+import org.pentaho.di.trans.dataservice.serialization.DataServiceFactory;
 import org.pentaho.di.trans.dataservice.serialization.DataServiceMetaStoreUtil;
 import org.pentaho.di.trans.dataservice.ui.DataServiceDelegate;
 import org.pentaho.di.trans.dataservice.ui.UIFactory;
@@ -80,6 +84,7 @@ public abstract class BaseTest {
   @Mock protected UIFactory uiFactory;
   @Mock protected LogChannelInterface logChannel;
   @Mock protected Cache<Integer, String> cache;
+  @Mock protected DataServiceFactory factory;
   @Mock protected DataServiceClient client;
 
   protected DataServiceDelegate delegate;
@@ -132,6 +137,10 @@ public abstract class BaseTest {
     when( metaStoreUtil.getContext() ).thenReturn( context );
     when( metaStoreUtil.getStepCache() ).thenReturn( cache );
     when( metaStoreUtil.getLogChannel() ).thenReturn( logChannel );
+
+    when( metaStoreUtil.createFactory( Matchers.<Supplier<Repository>>any() ) ).thenReturn( factory );
+    when( factory.getLogChannel() ).thenReturn( logChannel );
+    when( factory.createClient() ).thenReturn( client );
   }
 
 }

--- a/src/test/java/org/pentaho/di/trans/dataservice/DataServiceContextTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/DataServiceContextTest.java
@@ -68,7 +68,7 @@ public class DataServiceContextTest extends BaseTest {
 
   @Test
   public void testGetDataServiceClient() throws Exception {
-    assertThat( context.getDataServiceClient(), notNullValue() );
+    assertThat( context.createLocalClient(), notNullValue() );
   }
 
   @Test

--- a/src/test/java/org/pentaho/di/trans/dataservice/DataServiceExecutorTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/DataServiceExecutorTest.java
@@ -23,29 +23,29 @@
 package org.pentaho.di.trans.dataservice;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.pentaho.di.core.Condition;
-import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogLevel;
 import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.sql.SQL;
 import org.pentaho.di.trans.RowProducer;
 import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransListener;
 import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.dataservice.optimization.PushDownOptimizationMeta;
 import org.pentaho.di.trans.dataservice.optimization.ValueMetaResolver;
 import org.pentaho.di.trans.step.RowListener;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepListener;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -53,53 +53,38 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pentaho.di.trans.dataservice.testing.answers.ReturnsSelf.RETURNS_SELF;
 
-public class DataServiceExecutorTest {
+public class DataServiceExecutorTest extends BaseTest {
 
-  public static final String SERVICE_NAME = "serviceName";
-  public static final String SERVICE_STEP_NAME = "Service Step";
   public static final String INJECTOR_STEP_NAME = "Injector Step";
   public static final String RESULT_STEP_NAME = "Result Step";
-  private TransMeta transMeta;
-  private DataServiceMeta service;
-
-  @BeforeClass
-  public static void init() throws KettleException {
-    KettleEnvironment.init();
-  }
 
   @Before
   public void setUp() throws Exception {
-    transMeta = mock( TransMeta.class, RETURNS_DEEP_STUBS );
-    when( transMeta.listVariables() ).thenReturn( new String[0] );
-    when( transMeta.listParameters() ).thenReturn( new String[0] );
-    Answer<TransMeta> clone = new Answer<TransMeta>() {
-      private TransMeta clone = null;
-
-      @Override public TransMeta answer( InvocationOnMock invocation ) throws Throwable {
-        if ( clone == null ) {
-          clone = transMeta;
-        }
-        return clone;
-      }
-    };
-    when( transMeta.realClone( anyBoolean() ) ).thenAnswer( clone );
-    when( transMeta.clone() ).thenAnswer( clone );
-
-    service = new DataServiceMeta( transMeta );
-    service.setName( SERVICE_NAME );
-    service.setStepname( SERVICE_STEP_NAME );
+    doAnswer( RETURNS_SELF ).when( transMeta ).realClone( anyBoolean() );
+    doAnswer( RETURNS_SELF ).when( transMeta ).clone();
   }
 
   @Test
@@ -110,7 +95,7 @@ public class DataServiceExecutorTest {
     TransMeta genTransMeta = mock( TransMeta.class );
     when( genTrans.getTransMeta() ).thenReturn( genTransMeta );
 
-    new DataServiceExecutor.Builder( new SQL( "SELECT foo FROM " + SERVICE_NAME ), service ).
+    new DataServiceExecutor.Builder( new SQL( "SELECT foo FROM " + DATA_SERVICE_NAME ), dataService ).
       serviceTrans( serviceTrans ).
       genTrans( genTrans ).
       prepareExecution( false ).
@@ -126,23 +111,23 @@ public class DataServiceExecutorTest {
   @Test
   public void testConditionResolution() throws Exception {
     RowMeta rowMeta = new RowMeta();
-    rowMeta.addValueMeta( new ValueMeta( "aString", ValueMeta.TYPE_STRING ) );
-    rowMeta.addValueMeta( new ValueMeta( "anInt", ValueMeta.TYPE_INTEGER ) );
-    rowMeta.addValueMeta( new ValueMeta( "aDate", ValueMeta.TYPE_DATE ) );
+    rowMeta.addValueMeta( new ValueMetaString( "aString" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "anInt" ) );
+    rowMeta.addValueMeta( new ValueMetaDate( "aDate" ) );
 
-    String query = "SELECT * FROM " + SERVICE_NAME + " WHERE anInt = 2 AND aDate IN ('2014-12-05','2008-01-01')";
+    String query = "SELECT * FROM " + DATA_SERVICE_NAME + " WHERE anInt = 2 AND aDate IN ('2014-12-05','2008-01-01')";
 
-    TransMeta transMeta = this.transMeta;
-    when( transMeta.getStepFields( SERVICE_STEP_NAME ) ).thenReturn( rowMeta );
+    when( transMeta.getStepFields( DATA_SERVICE_STEP ) ).thenReturn( rowMeta );
 
-    DataServiceExecutor executor = new DataServiceExecutor.Builder( new SQL( query ), service ).
-        serviceTrans( transMeta ).
-        prepareExecution( false ).
-        build();
+    DataServiceExecutor executor = new DataServiceExecutor.Builder( new SQL( query ), dataService ).
+      serviceTrans( transMeta ).
+      prepareExecution( false ).
+      build();
 
     Condition condition = executor.getSql().getWhereCondition().getCondition();
 
-    assertEquals( condition.getCondition( 0 ).getRightExact().getValueMeta().getType(), ValueMeta.TYPE_INTEGER );
+    assertEquals( condition.getCondition( 0 ).getRightExact().getValueMeta().getType(),
+      ValueMetaInterface.TYPE_INTEGER );
     String dateList = condition.getCondition( 1 ).getRightExactString();
     for ( Object date : new ValueMetaResolver( rowMeta ).inListToTypedObjectArray( "aDate", dateList ) ) {
       assertThat( date, instanceOf( Date.class ) );
@@ -153,36 +138,55 @@ public class DataServiceExecutorTest {
   public void testExecuteQuery() throws Exception {
     Trans serviceTrans = mock( Trans.class, RETURNS_DEEP_STUBS );
     Trans genTrans = mock( Trans.class, RETURNS_DEEP_STUBS );
-    SQL sql = mock( SQL.class );
-    when( sql.getServiceName() ).thenReturn( SERVICE_NAME );
+    SQL sql = new SQL( "SELECT * FROM " + DATA_SERVICE_NAME );
     SqlTransGenerator sqlTransGenerator = mockSqlTransGenerator();
-    StepInterface serviceStep = serviceTrans.findRunThread( SERVICE_STEP_NAME );
+    StepInterface serviceStep = serviceTrans.findRunThread( DATA_SERVICE_STEP );
     StepInterface resultStep = genTrans.findRunThread( RESULT_STEP_NAME );
 
-    when( sql.getWhereClause() ).thenReturn( null );
     when( serviceTrans.getTransMeta().listParameters() ).thenReturn( new String[0] );
 
-    RowListener clientRowListener = mock( RowListener.class );
+    PushDownOptimizationMeta optimization = mock( PushDownOptimizationMeta.class );
+    when( optimization.isEnabled() ).thenReturn( true );
+    dataService.getPushDownOptimizationMeta().add( optimization );
 
-    DataServiceExecutor executor = new DataServiceExecutor.Builder( sql, service ).
-        serviceTrans( serviceTrans ).
-        sqlTransGenerator( sqlTransGenerator ).
-        genTrans( genTrans ).
-        build();
+    DataServiceExecutor executor = new DataServiceExecutor.Builder( sql, dataService ).
+      serviceTrans( serviceTrans ).
+      sqlTransGenerator( sqlTransGenerator ).
+      genTrans( genTrans ).
+      build();
+
+    ArgumentCaptor<String> objectIds = ArgumentCaptor.forClass( String.class );
+    verify( serviceTrans ).setContainerObjectId( objectIds.capture() );
+    when( serviceTrans.getContainerObjectId() ).thenReturn( objectIds.getValue() );
+    verify( genTrans ).setContainerObjectId( objectIds.capture() );
+    when( genTrans.getContainerObjectId() ).thenReturn( objectIds.getValue() );
+
+    RowProducer sqlTransRowProducer = mock( RowProducer.class );
+    when( genTrans.addRowProducer( INJECTOR_STEP_NAME, 0 ) ).thenReturn( sqlTransRowProducer );
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
     // Start Execution
-    executor.executeQuery( clientRowListener );
+    executor.executeQuery( new DataOutputStream( outputStream ) );
+
+    // Check header was written
+    assertThat( outputStream.size(), greaterThan( 0 ) );
+    outputStream.reset();
 
     InOrder genTransStartup = inOrder( genTrans, resultStep );
-    InOrder serviceTransStartup = inOrder( serviceTrans, serviceStep );
+    InOrder serviceTransStartup = inOrder( optimization, serviceTrans, serviceStep );
     ArgumentCaptor<RowListener> listenerArgumentCaptor = ArgumentCaptor.forClass( RowListener.class );
     ArgumentCaptor<StepListener> resultStepListener = ArgumentCaptor.forClass( StepListener.class );
+    ArgumentCaptor<TransListener> transListenerCaptor = ArgumentCaptor.forClass( TransListener.class );
 
+    genTransStartup.verify( genTrans ).addTransListener( transListenerCaptor.capture() );
     genTransStartup.verify( genTrans ).addRowProducer( INJECTOR_STEP_NAME, 0 );
     genTransStartup.verify( resultStep ).addStepListener( resultStepListener.capture() );
-    genTransStartup.verify( resultStep ).addRowListener( clientRowListener );
+    genTransStartup.verify( resultStep ).addRowListener( listenerArgumentCaptor.capture() );
+    RowListener clientRowListener = listenerArgumentCaptor.getValue();
     genTransStartup.verify( genTrans ).startThreads();
 
+    serviceTransStartup.verify( optimization ).activate( executor );
     serviceTransStartup.verify( serviceStep ).addRowListener( listenerArgumentCaptor.capture() );
     serviceTransStartup.verify( serviceTrans ).startThreads();
 
@@ -190,11 +194,11 @@ public class DataServiceExecutorTest {
     RowListener serviceRowListener = listenerArgumentCaptor.getValue();
     assertNotNull( serviceRowListener );
 
-    RowProducer sqlTransRowProducer = genTrans.addRowProducer( INJECTOR_STEP_NAME, 0 );
     // Push row from service to sql Trans
     RowMeta rowMeta = mock( RowMeta.class );
+    Object[] data;
     for ( int i = 0; i < 50; i++ ) {
-      Object[] data = new Object[] { i };
+      data = new Object[] { i };
 
       serviceRowListener.rowWrittenEvent( rowMeta, data );
       verify( sqlTransRowProducer ).putRowWait( same( rowMeta ), eq( data ), any( Long.class ), any( TimeUnit.class ) );
@@ -209,22 +213,43 @@ public class DataServiceExecutorTest {
     verify( serviceStep ).addStepListener( serviceStepListener.capture() );
     serviceStepListener.getValue().stepFinished( serviceTrans, serviceStep.getStepMeta(), serviceStep );
     verify( sqlTransRowProducer ).finished();
+
+    // Push row from service to sql Trans
+    for ( int i = 0; i < 50; i++ ) {
+      Object[] row = { i };
+      clientRowListener.rowWrittenEvent( rowMeta, row );
+    }
+
+    InOrder writeRows = inOrder( rowMeta );
+    ArgumentCaptor<DataOutputStream> streamCaptor = ArgumentCaptor.forClass( DataOutputStream.class );
+    writeRows.verify( rowMeta ).writeMeta( streamCaptor.capture() );
+    DataOutputStream dataOutputStream = streamCaptor.getValue();
+    writeRows.verify( rowMeta, times( 50 ) ).writeData( same( dataOutputStream ), argThat( arrayWithSize( 1 ) ) );
+
+    // Gen trans finished, assert no more data is written
+    outputStream.reset();
+    transListenerCaptor.getValue().transFinished( genTrans );
+    assertThat( outputStream.size(), equalTo( 0 ) );
+
+    executor.waitUntilFinished();
+    verify( serviceTrans ).waitUntilFinished();
+    verify( genTrans ).waitUntilFinished();
   }
 
   @Test
   public void testQueryWithParams() throws Exception {
-    String sql = "SELECT * FROM " + SERVICE_NAME + " WHERE PARAMETER('foo') = 'bar' AND PARAMETER('baz') = 'bop'";
+    String sql = "SELECT * FROM " + DATA_SERVICE_NAME + " WHERE PARAMETER('foo') = 'bar' AND PARAMETER('baz') = 'bop'";
     Trans serviceTrans = mock( Trans.class, RETURNS_DEEP_STUBS );
     Trans genTrans = mock( Trans.class, RETURNS_DEEP_STUBS );
     SqlTransGenerator sqlTransGenerator = mockSqlTransGenerator();
 
     final SQL theSql = new SQL( sql );
 
-    DataServiceExecutor executor = new DataServiceExecutor.Builder( theSql, service ).
-        serviceTrans( serviceTrans ).
-        sqlTransGenerator( sqlTransGenerator ).
-        genTrans( genTrans ).
-        build();
+    DataServiceExecutor executor = new DataServiceExecutor.Builder( theSql, dataService ).
+      serviceTrans( serviceTrans ).
+      sqlTransGenerator( sqlTransGenerator ).
+      genTrans( genTrans ).
+      build();
 
     List<Condition> conditions = theSql.getWhereCondition().getCondition().getChildren();
 
@@ -249,17 +274,17 @@ public class DataServiceExecutorTest {
 
   @Test
   public void testNullNotNullKeywords() throws Exception {
-    String sql = "SELECT * FROM " + SERVICE_NAME + " WHERE column1 IS NOT NULL AND column2 IS NULL";
+    String sql = "SELECT * FROM " + DATA_SERVICE_NAME + " WHERE column1 IS NOT NULL AND column2 IS NULL";
 
     Trans serviceTrans = mock( Trans.class, RETURNS_DEEP_STUBS );
     Trans genTrans = mock( Trans.class, RETURNS_DEEP_STUBS );
     SqlTransGenerator sqlTransGenerator = mockSqlTransGenerator();
 
-    DataServiceExecutor executor = new DataServiceExecutor.Builder( new SQL( sql ), service ).
-        serviceTrans( serviceTrans ).
-        sqlTransGenerator( sqlTransGenerator ).
-        genTrans( genTrans ).
-        build();
+    DataServiceExecutor executor = new DataServiceExecutor.Builder( new SQL( sql ), dataService ).
+      serviceTrans( serviceTrans ).
+      sqlTransGenerator( sqlTransGenerator ).
+      genTrans( genTrans ).
+      build();
 
     Condition condition = executor.getSql().getWhereCondition().getCondition();
 
@@ -276,22 +301,23 @@ public class DataServiceExecutorTest {
   }
 
   @Test
-  public void testWithLazyConversion () throws Exception {
+  public void testWithLazyConversion() throws Exception {
     RowMeta rowMeta = new RowMeta();
-    ValueMeta vm = new ValueMeta( "aBinaryStoredString", ValueMeta.TYPE_STRING, ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
+    ValueMetaInterface vm = new ValueMetaString( "aBinaryStoredString" );
+    vm.setStorageType( ValueMetaInterface.STORAGE_TYPE_BINARY_STRING );
     vm.setStorageMetadata( new ValueMetaString() );
     rowMeta.addValueMeta( vm );
 
-    String query = "SELECT * FROM " + SERVICE_NAME + " WHERE aBinaryStoredString = 'value'";
+    String query = "SELECT * FROM " + DATA_SERVICE_NAME + " WHERE aBinaryStoredString = 'value'";
 
-    when( transMeta.getStepFields( SERVICE_STEP_NAME ) ).thenReturn( rowMeta );
+    when( transMeta.getStepFields( DATA_SERVICE_STEP ) ).thenReturn( rowMeta );
 
-    DataServiceExecutor executor = new DataServiceExecutor.Builder( new SQL( query ), service ).
-        serviceTrans( new Trans(transMeta) ).
-        prepareExecution( false ).
-        build();
+    DataServiceExecutor executor = new DataServiceExecutor.Builder( new SQL( query ), dataService ).
+      serviceTrans( new Trans( transMeta ) ).
+      prepareExecution( false ).
+      build();
 
-    executor.getSql().getWhereCondition().getCondition().evaluate( rowMeta, new Object[] {"value".getBytes()} );
+    executor.getSql().getWhereCondition().getCondition().evaluate( rowMeta, new Object[] { "value".getBytes() } );
   }
 
   private SqlTransGenerator mockSqlTransGenerator() {

--- a/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
@@ -43,7 +43,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.OutputStream;
 import java.sql.SQLException;
 
 import static org.hamcrest.Matchers.anything;
@@ -109,7 +108,7 @@ public class DataServiceClientTest extends BaseTest {
     builder = mock( DataServiceExecutor.Builder.class, RETURNS_SELF );
     when( context.createBuilder( argThat( isTestSqlQuery() ), same( dataService ) ) ).thenReturn( builder );
     doReturn( executor ).when( builder ).build();
-    when( executor.executeQuery( any( OutputStream.class ) ) ).thenReturn( executor );
+    when( executor.executeQuery( any( DataOutputStream.class ) ) ).thenReturn( executor );
 
     dataServiceClient = new DataServiceClient( context );
     dataServiceClient.setMetaStore( metaStore );

--- a/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
@@ -33,10 +33,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.sql.SQL;
-import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.dataservice.BaseTest;
 import org.pentaho.di.trans.dataservice.DataServiceExecutor;
-import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
 import java.io.ByteArrayInputStream;
@@ -82,12 +80,6 @@ public class DataServiceClientTest extends BaseTest {
   private static final String TEST_SQL_QUERY = "SELECT * FROM " + DATA_SERVICE_NAME;
   private static final int MAX_ROWS = 100;
 
-  @Mock
-  private Repository repository;
-
-  @Mock
-  private IMetaStore metaStore;
-
   private DataServiceExecutor.Builder builder;
 
   @Mock
@@ -102,7 +94,10 @@ public class DataServiceClientTest extends BaseTest {
 
   @Before
   public void setUp() throws Exception {
-    when( metaStoreUtil.getDataService( DATA_SERVICE_NAME, repository, metaStore ) ).thenReturn( dataService );
+    when( factory.getDataService( DATA_SERVICE_NAME ) ).thenReturn( dataService );
+    when( factory.logErrors( anyString() ) ).thenReturn( exceptionHandler );
+    when( factory.getDataServices( exceptionHandler ) ).thenReturn( ImmutableList.of( dataService ) );
+
     sql = new SQL( TEST_SQL_QUERY );
 
     builder = mock( DataServiceExecutor.Builder.class, RETURNS_SELF );
@@ -110,9 +105,7 @@ public class DataServiceClientTest extends BaseTest {
     doReturn( executor ).when( builder ).build();
     when( executor.executeQuery( any( DataOutputStream.class ) ) ).thenReturn( executor );
 
-    dataServiceClient = new DataServiceClient( context );
-    dataServiceClient.setMetaStore( metaStore );
-    dataServiceClient.setRepository( repository );
+    dataServiceClient = new DataServiceClient( context, factory );
   }
 
   @Test
@@ -126,7 +119,7 @@ public class DataServiceClientTest extends BaseTest {
     verify( logChannel, never() ).logError( anyString(), any( Throwable.class ) );
 
     MetaStoreException exception = new MetaStoreException();
-    when( metaStoreUtil.getDataService( DATA_SERVICE_NAME, repository, metaStore ) ).thenThrow( exception );
+    when( factory.getDataService( DATA_SERVICE_NAME ) ).thenThrow( exception );
     try {
       assertThat( dataServiceClient.query( TEST_SQL_QUERY, MAX_ROWS ), not( anything() ) );
     } catch ( SQLException e ) {
@@ -154,10 +147,6 @@ public class DataServiceClientTest extends BaseTest {
   @Test
   public void testGetServiceInformation() throws Exception {
     when( transMeta.getStepFields( dataService.getStepname() ) ).thenReturn( rowMetaInterface );
-
-    when( metaStoreUtil.logErrors( anyString() ) ).thenReturn( exceptionHandler );
-    when( metaStoreUtil.getDataServices( repository, metaStore, exceptionHandler ) )
-      .thenReturn( ImmutableList.of( dataService ) );
 
     assertThat( dataServiceClient.getServiceInformation(), contains( allOf(
       hasProperty( "name", equalTo( DATA_SERVICE_NAME ) ),

--- a/src/test/java/org/pentaho/di/trans/dataservice/serialization/DataServiceFactoryTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/serialization/DataServiceFactoryTest.java
@@ -1,0 +1,94 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.serialization;
+
+import com.google.common.base.Supplier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.dataservice.clients.DataServiceClient;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.stores.memory.MemoryMetaStore;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author nhudak
+ */
+
+@RunWith( org.mockito.runners.MockitoJUnitRunner.class )
+public class DataServiceFactoryTest extends DataServiceMetaStoreUtilTest {
+  @Mock Supplier<Repository> supplier;
+
+  public void setUp() throws Exception {
+    super.setUp();
+
+    when( supplier.get() ).thenReturn( repository );
+    metaStoreUtil = factory = metaStoreUtil.createFactory( supplier );
+  }
+
+  @Test
+  public void testGetDataService() throws Exception {
+    assertThat( factory.getDataServiceNames(), empty() );
+    metaStoreUtil.save( dataService );
+    metaStoreUtil.sync( transMeta, exceptionHandler );
+
+    assertThat( factory.getDataServiceNames(), contains( DATA_SERVICE_NAME ) );
+    assertThat( factory.getDataService( DATA_SERVICE_NAME ), validDataService() );
+    assertThat( factory.getDataServices( exceptionHandler ), contains( validDataService() ) );
+
+    verify( exceptionHandler, never() ).apply( any( Exception.class ) );
+  }
+
+  @Test
+  public void testCreateClient() throws Exception {
+    DataServiceClient client = factory.createClient();
+    metaStoreUtil.save( dataService );
+    metaStoreUtil.sync( transMeta, exceptionHandler );
+
+    assertThat( client.getServiceInformation(), contains( hasProperty( "name", equalTo( DATA_SERVICE_NAME ) ) ) );
+  }
+
+  @Test
+  public void testLocalMetaStore() throws Exception {
+    DataServiceFactory.localPentahoMetaStore = new MemoryMetaStore();
+
+    assertThat( factory.getRepository(), sameInstance( repository ) );
+    assertThat( factory.getMetaStore(), sameInstance( (IMetaStore) metaStore ) );
+
+    when( supplier.get() ).thenReturn( null );
+    assertThat( factory.getRepository(), nullValue() );
+    assertThat( factory.getMetaStore(), sameInstance( DataServiceFactory.localPentahoMetaStore ) );
+  }
+}

--- a/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
@@ -142,7 +142,7 @@ public class TransDataServletTest extends BaseTest {
     when( builder.parameters( anyMapOf( String.class, String.class ) ) ).thenReturn( builder );
     when( builder.rowLimit( Integer.valueOf( TEST_MAX_ROWS ) ) ).thenReturn( builder );
     when( builder.build() ).thenReturn( executor );
-    when( executor.executeQuery( outputStream ) ).thenReturn( executor );
+    when( executor.executeQuery( (DataOutputStream) any() ) ).thenReturn( executor );
     when( executor.getServiceTransMeta() ).thenReturn( transMeta );
     when( executor.getServiceTrans() ).thenReturn( serviceTrans );
     when( executor.getGenTransMeta() ).thenReturn( genTransMeta );
@@ -186,7 +186,7 @@ public class TransDataServletTest extends BaseTest {
     verify( builder ).parameters( anyMapOf( String.class, String.class ) );
     verify( builder ).rowLimit( Integer.valueOf( TEST_MAX_ROWS ) );
     verify( builder ).build();
-    verify( executor ).executeQuery( outputStream );
+    verify( executor ).executeQuery( (DataOutputStream) any() );
     verify( executor ).getServiceTransMeta();
     verify( executor ).getServiceTrans();
     verify( transformationMap, times( 2 ) )


### PR DESCRIPTION
Bind DataServiceClient to a repository source, eliminating the need set repository and metastore before each query. If no repository is available, the user's local default metastore is used.

http://jira.pentaho.com/browse/PDI-14537