### PR TITLE
[BACKLOG-5460]DISTINCT requires complete cache

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedService.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedService.java
@@ -113,7 +113,9 @@ class CachedService implements Serializable {
       return true;
     }
     // If aggregate functions or grouping is queried, a complete set is needed
-    if ( !sql.getGroupFields().getFields().isEmpty() || !sql.getSelectFields().getAggregateFields().isEmpty() ) {
+    SQLFields selectFields = sql.getSelectFields();
+    SQLFields groupFields = sql.getGroupFields();
+    if ( selectFields.hasAggregates() || selectFields.isDistinct() || !groupFields.getFields().isEmpty() ) {
       return false;
     }
     // Compare ranking

--- a/src/test/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedServiceTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedServiceTest.java
@@ -450,6 +450,14 @@ public class CachedServiceTest {
     // Only complete sets will answer a GROUP BY query
     assertThat( partial.answersQuery( dataServiceExecutor( query + groupBy ) ), is( false ) );
     assertThat( complete.answersQuery( dataServiceExecutor( query + groupBy ) ), is( true ) );
+
+    String distinctQuery = "SELECT DISTINCT ID FROM " + SERVICE_NAME + limit;
+    assertThat( partial.answersQuery( dataServiceExecutor( distinctQuery ) ), is( false ) );
+    assertThat( complete.answersQuery( dataServiceExecutor( distinctQuery ) ), is( true ) );
+
+    String aggregateQuery = "SELECT count(*) FROM " + SERVICE_NAME;
+    assertThat( partial.answersQuery( dataServiceExecutor( aggregateQuery ) ), is( false ) );
+    assertThat( complete.answersQuery( dataServiceExecutor( aggregateQuery ) ), is( true ) );
   }
 
   private CachedService partial( DataServiceExecutor executor ) {


### PR DESCRIPTION
Only use cache for answering a 'SELECT DISTINCT ...' query when a complete result set is available

http://jira.pentaho.com/browse/BACKLOG-5460
[![Build Status](https://travis-ci.org/hudak/pdi-dataservice-server-plugin.svg?branch=BACKLOG-5460)](https://travis-ci.org/hudak/pdi-dataservice-server-plugin)