### PR TITLE
[BACKLOG-8518]Executor should write RowMeta once

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/DataServiceExecutor.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/DataServiceExecutor.java
@@ -363,7 +363,7 @@ public class DataServiceExecutor {
     //
     getGenTrans().addTransListener( new TransAdapter() {
       @Override public void transFinished( Trans trans ) throws KettleException {
-        if ( !rowMetaWritten.compareAndSet( false, true ) ) {
+        if ( rowMetaWritten.compareAndSet( false, true ) ) {
           RowMetaInterface stepFields = trans.getTransMeta().getStepFields( getResultStepName() );
           stepFields.writeMeta( dos );
         }


### PR DESCRIPTION
Logical error writes rowMeta after data is complete.
Should write meta only once, either before the first row or after the trans has finished if empty

[![Build Status](https://travis-ci.org/hudak/pdi-dataservice-server-plugin.svg?branch=master)](https://travis-ci.org/hudak/pdi-dataservice-server-plugin)

http://jira.pentaho.com/browse/BACKLOG-5818