### PR TITLE
[BACKLOG-4455] In Data Service Test dialog, current data service must be specified

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceDialogController.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceDialogController.java
@@ -22,11 +22,8 @@
 
 package org.pentaho.di.trans.dataservice.ui.controller;
 
-import static org.pentaho.di.i18n.BaseMessages.getString;
-
-import java.lang.reflect.InvocationTargetException;
-
-import org.pentaho.di.core.Const;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.dataservice.DataServiceMeta;
 import org.pentaho.di.trans.dataservice.serialization.DataServiceValidationException;
@@ -41,7 +38,9 @@ import org.pentaho.ui.xul.components.XulMenuList;
 import org.pentaho.ui.xul.components.XulTextbox;
 import org.pentaho.ui.xul.swt.tags.SwtDialog;
 
-import com.google.common.collect.ImmutableList;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.pentaho.di.i18n.BaseMessages.getString;
 
 public class DataServiceDialogController extends AbstractController {
   public static final String XUL_DIALOG_ID = "dataservice-dialog";
@@ -76,9 +75,7 @@ public class DataServiceDialogController extends AbstractController {
   }
 
   public void showTestDialog() throws XulException {
-    if ( Const.isEmpty( model.getServiceName() ) ) {
-      error( getString( PKG, "DataServiceDialog.TestError.Title" ), getString( PKG,
-          "DataServiceDialog.TestError.NameMissing" ) );
+    if ( dataServiceHasNoName( model ) ) {
       return;
     }
 
@@ -87,6 +84,10 @@ public class DataServiceDialogController extends AbstractController {
 
   public void saveAndClose() throws XulException {
     try {
+      if ( dataServiceHasNoName( model ) ) {
+        return;
+      }
+
       String existing = dataService != null ? dataService.getName() : null;
 
       delegate.save( delegate.checkConflict( delegate.checkDefined( model.getDataService() ), existing ) );
@@ -133,5 +134,15 @@ public class DataServiceDialogController extends AbstractController {
 
   public void setDataService( DataServiceMeta dataService ) {
     this.dataService = dataService;
+  }
+
+  private boolean dataServiceHasNoName( DataServiceModel serviceModel ) throws XulException {
+    boolean noName = Strings.isNullOrEmpty( serviceModel.getServiceName() );
+    if ( noName ) {
+      error( getString( PKG, "DataServiceDialog.NameMissingError.Title" ), getString( PKG,
+          "DataServiceDialog.NameMissingError.Message" ) );
+    }
+
+    return noName;
   }
 }

--- a/src/main/resources/org/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
@@ -63,8 +63,8 @@ DataServiceDialog.Help.Button=Help
 DataServiceDialog.OK.Button=OK
 DataServiceDialog.Cancel.Button=Cancel
 DataServiceDialog.SaveError.Title=Error Saving Data Service
-DataServiceDialog.TestError.Title=Error Testing Data Service
-DataServiceDialog.TestError.NameMissing=Data Service does not have a name specified
+DataServiceDialog.NameMissingError.Title=Missing Data Service Name
+DataServiceDialog.NameMissingError.Message=Please provide a name for the Data Service.
 DataServiceDialog.Help.Title=Help for Pentaho Data Services
 DataServiceDialog.Help.Url=https://help.pentaho.com/Documentation/6.0/0L0/0Y0/090/020
 


### PR DESCRIPTION
Changed error message on empty DS name according to UX review.
@hudak please review. Should Test button be disabled if name is empty?