### PR TITLE
[BACKLOG-6650] Test dataservice dialog should quote the tablename

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceTestController.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceTestController.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -245,7 +245,7 @@ public class DataServiceTestController extends AbstractXulEventHandler {
   }
 
   private String getDefaultSql() {
-    return "SELECT * FROM " + dataService.getName();
+    return "SELECT * FROM \"" + dataService.getName() + "\"";
   }
 
   public void executeSql() throws KettleException {


### PR DESCRIPTION
in the default SQL.

This prevents errors/ambiguity if there are spaces within the name.