### PR TITLE
[SP-2751] Backport of PDI-15153 - Creating Data Services via View Panel - New Data Service - Parameter Pushdown - Error with Parameters not showing up (6.1 Suite)

### DIFF
--- a/src/test/java/org/pentaho/di/trans/dataservice/ui/DataServiceDelegateTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/ui/DataServiceDelegateTest.java
@@ -52,7 +52,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyString;
 
 @RunWith( MockitoJUnitRunner.class )
 public class DataServiceDelegateTest extends BaseTest {


### PR DESCRIPTION
Consiquence of [this change] (https://github.com/pentaho/pdi-dataservice-server-plugin/pull/180/files#diff-2aec19034e99fdc5d19e2b6693cdf073R55).
Since we import `Mockito.*`,  `Matchers.contains` method messed up with `Mockito.contains`.
It wasn't seen from IDE unfortunately.