### PR TITLE
[BACKLOG-11615]Fix Dataservice Mem problems

### DIFF
--- a/src/main/resources/OSGI-INF/blueprint/services.xml
+++ b/src/main/resources/OSGI-INF/blueprint/services.xml
@@ -53,6 +53,7 @@
     <bean id="dataServiceClient" class="org.pentaho.di.trans.dataservice.clients.DataServiceClient">
         <argument ref="queryServiceDelegate"/>
         <argument ref="dataServiceResolverDelegate"/>
+        <argument ref="executor"/>
         <property name="logChannel" ref="logChannel"/>
     </bean>
 

--- a/src/test/java/org/pentaho/di/trans/dataservice/serialization/DataServiceFactoryTest.java
+++ b/src/test/java/org/pentaho/di/trans/dataservice/serialization/DataServiceFactoryTest.java
@@ -35,7 +35,8 @@ import org.pentaho.di.trans.dataservice.resolvers.MetaStoreResolver;
 import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.metastore.stores.memory.MemoryMetaStore;
 import org.pentaho.osgi.kettle.repository.locator.api.KettleRepositoryLocator;
-import org.pentaho.osgi.kettle.repository.locator.api.KettleRepositoryProvider;
+
+import java.util.concurrent.Executors;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -94,7 +95,7 @@ public class DataServiceFactoryTest extends DataServiceMetaStoreUtilTest {
     when( repositoryLocator.getRepository() ).thenReturn( repository );
     DataServiceResolver dataServiceResolver = new MetaStoreResolver( repositoryLocator, context );
 
-    DataServiceClient client = new DataServiceClient( queryService, dataServiceResolver );
+    DataServiceClient client = new DataServiceClient( queryService, dataServiceResolver, Executors.newCachedThreadPool() );
     metaStoreUtil.save( dataService );
     metaStoreUtil.sync( transMeta, exceptionHandler );
 


### PR DESCRIPTION
* Replaced concurrent map in context with in-memory cache to prevent leaks
* Replaced Byte Array streams with pipe to improve performance and memory footprint

http://jira.pentaho.com/browse/BACKLOG-11615

@pamval @mkambol 