### PR TITLE
[BACKLOG-10097] As a new user to Pentaho and creating a connection to…

### DIFF
--- a/src/main/resources/org/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/dataservice/ui/messages/messages_en_US.properties
@@ -67,7 +67,7 @@ DataServiceDialog.SaveError.Title=Error Saving Data Service
 DataServiceDialog.NameMissingError.Title=Missing Data Service Name
 DataServiceDialog.NameMissingError.Message=Please provide a name for the Data Service.
 DataServiceDialog.Help.Title=Help for Pentaho Data Services
-DataServiceDialog.Help.Url=https://help.pentaho.com/Documentation/6.1/0L0/0Y0/090/020
+DataServiceDialog.Help.Url=https://help.pentaho.com/Documentation/7.0/0L0/0Y0/090/020
 
 DataServiceDelegate.DeleteDataService.Title=Delete Data Service
 DataServiceDelegate.DeleteDataService.Message=Are you sure you want to delete the [{0}] Data Service?
@@ -94,7 +94,7 @@ DriverDetailsDialog.GetDriver.Button=Get Driver…
 DriverDetailsDialog.Help.Button=Help
 DriverDetailsDialog.Close.Button=Close
 DriverDetailsDialog.ConnectionSetupLink.Label=Help for Pentaho Data Service Driver
-DriverDetailsDialog.ConnectionSetupLink.Url=https://help.pentaho.com/Documentation/6.1/0L0/0Y0/090/040#Connect_to_the_Pentaho_Data_Service_from_a_Non-Pentaho_Tool
+DriverDetailsDialog.ConnectionSetupLink.Url=https://help.pentaho.com/Documentation/7.0/0L0/0Y0/090/040#Connect_to_the_Pentaho_Data_Service_from_a_Non-Pentaho_Tool
 DriverDetailsDialog.SaveDialog.DefaultFileName.Label=Pentaho-Data-Service-Driver.zip
 DriverDetailsDialog.SaveDialog.AllFilesFilter.Label=All files
 DriverDetailsDialog.SaveDialog.ZipFilesFilter.Label=Zip files


### PR DESCRIPTION
… Pentaho Data Services, I want the default web-app name for the Data Service driver to use 'pentaho' instead of 'pentaho-di' since there is no such web-app in 7.0
@mkambol @hudak 