### PR TITLE
[SP-3228][PDI-15584] It's possible to create data services with duplicate names via Save AS button for transformations

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/ui/DataServiceDelegate.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/ui/DataServiceDelegate.java
@@ -127,6 +127,7 @@ public class DataServiceDelegate extends DataServiceFactory {
         //can not exist duplicate, delete dataService and save transformation (PDI-15584)
         try {
           deleteDataServiceElementAndCleanCache( dataServiceMeta, serviceTrans );
+          serviceTrans.setChanged();
         } catch ( MetaStoreException e ) {
           getLogChannel().logBasic( e.getMessage() );
         }


### PR DESCRIPTION
[SP-3228][PDI-15584] It's possible to create data services with duplicate names via Save AS button for transformations
-added consistent behavior with YES button (affected when transformation and press Save as)
@kurtwalker Could you please review and merge it?