### PR TITLE
[BACKLOG-16227] Clone transient data service transmeta

### DIFF
--- a/src/main/java/org/pentaho/di/trans/dataservice/resolvers/TransientResolver.java
+++ b/src/main/java/org/pentaho/di/trans/dataservice/resolvers/TransientResolver.java
@@ -115,7 +115,7 @@ public class TransientResolver implements DataServiceResolver {
 
     Optional<TransMeta> transMeta;
     if ( spoonSupplier.get() != null && spoonSupplier.get().getActiveTransformation() != null ) {
-      transMeta = Optional.of( spoonSupplier.get().getActiveTransformation() );
+      transMeta = Optional.of( (TransMeta) spoonSupplier.get().getActiveTransformation().realClone( false ) );
     } else {
       // Try to locate the transformation, repository first
       transMeta = Stream.of( loadFromRepository(), TransMeta::new )


### PR DESCRIPTION
@ddiroma @mdamour1976 The transmeta gets cloned further down in the data service executor, but the annotations query didn't.