### PR TITLE
[BACKLOG-21568] Updates MongoDB driver from 3.2.2 to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <guava.version>17.0</guava.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <swt.version>4.6</swt.version>
-    <mongo.java.driver.version>3.2.2</mongo.java.driver.version>
+    <mongo.java.driver.version>3.6.3</mongo.java.driver.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <pentaho-modeler.version>${project.version}</pentaho-modeler.version>
     <rxjava.version>2.0.4</rxjava.version>


### PR DESCRIPTION
Related PRs:
https://github.com/pentaho/pentaho-mongodb-plugin/pull/164
https://github.com/pentaho/pentaho-mongo-utils/pull/65
https://github.com/pentaho/pdi-dataservice-server-plugin/pull/282
https://github.com/pentaho/pentaho-karaf-assembly/pull/421