### PR TITLE
[PDI-17671][CDE-987] The window fallback buffer should be reset each …

### DIFF
--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/DataServiceContext.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/DataServiceContext.java
@@ -70,7 +70,7 @@ public class DataServiceContext implements Context {
     .<String, DataServiceExecutor>build().asMap();
 
   // Use an in-memory cache with soft value references to prevent heap memory leaks
-  private final ConcurrentMap<StreamServiceKey, StreamingServiceTransExecutor> serviceExecutors = CacheBuilder.newBuilder()
+  private final Cache<StreamServiceKey, StreamingServiceTransExecutor> serviceExecutors = CacheBuilder.newBuilder()
     .expireAfterAccess( 1, TimeUnit.DAYS )
     .removalListener( new RemovalListener<StreamServiceKey, StreamingServiceTransExecutor>() {
       public void onRemoval( RemovalNotification<StreamServiceKey, StreamingServiceTransExecutor> removal ) {
@@ -83,7 +83,7 @@ public class DataServiceContext implements Context {
       }
     } )
     .softValues()
-    .<StreamServiceKey, StreamingServiceTransExecutor>build().asMap();
+    .<StreamServiceKey, StreamingServiceTransExecutor>build();
 
   public DataServiceContext( List<PushDownFactory> pushDownFactories,
                              List<AutoOptimizationService> autoOptimizationServices,
@@ -161,24 +161,25 @@ public class DataServiceContext implements Context {
 
   @Override
   public void addServiceTransExecutor( final StreamingServiceTransExecutor serviceExecutor ) {
-    serviceExecutors.putIfAbsent( serviceExecutor.getKey(), serviceExecutor );
+    serviceExecutors.put( serviceExecutor.getKey(), serviceExecutor );
   }
 
   @Override
   public StreamingServiceTransExecutor getServiceTransExecutor( StreamServiceKey key ) {
-    return serviceExecutors.get( key );
+    return serviceExecutors.getIfPresent( key );
   }
 
   @Override
   public void removeServiceTransExecutor( StreamServiceKey key ) {
-    serviceExecutors.remove( key );
+    serviceExecutors.invalidate( key );
+    serviceExecutors.cleanUp();
   }
 
   @Override
   public void removeServiceTransExecutor( String dataServiceName ) {
-    for ( StreamServiceKey key : serviceExecutors.keySet() ) {
+    for ( StreamServiceKey key : serviceExecutors.asMap().keySet() ) {
       if ( key.getDataServiceId().equals( dataServiceName ) ) {
-        serviceExecutors.remove( key );
+        removeServiceTransExecutor( key );
       }
     }
   }

--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/DataServiceMetaFactory.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/DataServiceMetaFactory.java
@@ -77,18 +77,6 @@ public class DataServiceMetaFactory implements IDataServiceMetaFactory {
     return dataServiceMeta;
   }
 
-  @Override public DataServiceMeta createStreamingDataService( StepMeta step ) throws KettleException {
-    TransMeta transformation = step.getParentTransMeta();
-
-    DataServiceMeta dataServiceMeta = new DataServiceMeta( transformation, true );
-
-    dataServiceMeta.setName( createDataServiceName( step, 0, true ) );
-    dataServiceMeta.setStepname( step.getName() );
-    dataServiceMeta.setRowLimit( 0 );
-
-    return dataServiceMeta;
-  }
-
   private String createDataServiceName( StepMeta step, Integer rowLimit, boolean streaming ) throws KettleException {
     TransMeta transMeta = step.getParentTransMeta();
     String fullFileName;

--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/IDataServiceMetaFactory.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/IDataServiceMetaFactory.java
@@ -29,7 +29,6 @@ import org.pentaho.di.trans.step.StepMeta;
 public interface IDataServiceMetaFactory {
   public DataServiceMeta createDataService( StepMeta step ) throws KettleException;
   public DataServiceMeta createDataService( StepMeta step, Integer rowLimit ) throws KettleException;
-  public DataServiceMeta createStreamingDataService( StepMeta step ) throws KettleException;
   public PushDownFactory getCacheFactory();
   public void setCacheFactory( PushDownFactory cacheFactory );
 }

--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/streaming/StreamServiceKey.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/streaming/StreamServiceKey.java
@@ -23,11 +23,11 @@
 package org.pentaho.di.trans.dataservice.streaming;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableMap;
 import org.pentaho.di.trans.dataservice.optimization.OptimizationImpactInfo;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,9 +69,9 @@ public class StreamServiceKey implements Serializable {
    * @return - The key for the given arguments.
    */
   public static StreamServiceKey create( String dataServiceId, Map<String, String> parameters, List<OptimizationImpactInfo> optimizationList ) {
-    // Copy execution parameters
-    Map<String, String> params = new HashMap<>();
-    params.putAll( parameters );
+    // Copy execution parameters (to be really unmodifiable, the below must be done - the unmodifiable references
+    // the argument list internally, allowing it to be changed outside and hence having it's contents also modified)
+    Map<String, String> params = Collections.unmodifiableMap( new HashMap<>( parameters ) );
 
     List<String> optimizations = new ArrayList<>();
     if ( optimizationList != null ) {
@@ -98,8 +98,8 @@ public class StreamServiceKey implements Serializable {
    *
    * @return - The parameters property.
    */
-  public ImmutableMap<String, String> getParameters() {
-    return ImmutableMap.copyOf( parameters );
+  public Map<String, String> getParameters() {
+    return parameters;
   }
 
   public List<String> getOptimizations() {

--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/streaming/execution/StreamingServiceTransExecutor.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/streaming/execution/StreamingServiceTransExecutor.java
@@ -36,7 +36,9 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.dataservice.Context;
+import org.pentaho.di.trans.dataservice.DataServiceExecutor;
 import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
+import org.pentaho.di.trans.dataservice.execution.CopyParameters;
 import org.pentaho.di.trans.dataservice.execution.PrepareExecution;
 import org.pentaho.di.trans.dataservice.execution.TransStarter;
 import org.pentaho.di.trans.dataservice.streaming.StreamList;
@@ -209,6 +211,12 @@ public class StreamingServiceTransExecutor {
    */
   private void startService() {
     lastCacheCleanupMillis = System.currentTimeMillis();
+
+    //Copy parameters into the service transformation
+    DataServiceExecutor dataServiceExecutor = context.getExecutor( serviceTrans.getContainerObjectId() );
+    if ( dataServiceExecutor != null ) {
+      new CopyParameters( dataServiceExecutor.getParameters(), serviceTrans ).run();
+    }
 
     PrepareExecution prepExec = new PrepareExecution( serviceTrans );
     Runnable serviceTransWiring = getServiceTransWiring();

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/DataServiceMetaFactoryTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/DataServiceMetaFactoryTest.java
@@ -159,14 +159,4 @@ public class DataServiceMetaFactoryTest {
     DataServiceMeta ds5 = factory.createDataService( stepMeta );
     assertTrue( TransientResolver.isTransient( ds5.getName() ) );
   }
-
-  @Test
-  public void testCreateStreamingDataService() throws Exception {
-    DataServiceMeta ds = factory.createStreamingDataService( stepMeta );
-    assertNotNull( ds );
-    assertEquals( transMeta, ds.getServiceTrans() );
-    assertEquals( stepName, ds.getStepname() );
-    assertEquals( 0, ds.getRowLimit() );
-    verify( factory, times( 1 ) ).createStreamingDataService( eq( stepMeta ) );
-  }
 }

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedServiceTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/optimization/cache/CachedServiceTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -170,12 +170,10 @@ public class CachedServiceTest {
     sql.parse( rowMeta );
 
     assertThat( CacheKey.create( new DataServiceExecutor.Builder( sql, dataServiceMeta, context )
-        .prepareExecution( false )
         .parameters( ImmutableMap.of( "foo", "bar" ) )
         .serviceTrans( serviceTrans )
         .build() ),
       not( equalTo( CacheKey.create( new DataServiceExecutor.Builder( sql, dataServiceMeta, context )
-        .prepareExecution( false )
         .serviceTrans( serviceTrans )
         .build() ) ) ) );
   }

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/streaming/StreamServiceKeyTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/streaming/StreamServiceKeyTest.java
@@ -31,6 +31,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.di.trans.dataservice.optimization.OptimizationImpactInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -182,5 +183,41 @@ public class StreamServiceKeyTest {
 
     key = StreamServiceKey.create( mockDataServiceId, mockParameters, mockOptimizationList );
     assertEquals( toStringTest, key.toString() );
+  }
+
+  @Test
+  public void testImmutable(){
+    Map<String, String> parameters = new HashMap<>( );
+    parameters.put( "key1", "value1" );
+    List<OptimizationImpactInfo> optimizations = new ArrayList<>();
+    OptimizationImpactInfo optimizationImpactInfo = new OptimizationImpactInfo( "STEP_NAME" );
+    optimizationImpactInfo.setQueryAfterOptimization( "AFTER" );
+    optimizations.add( optimizationImpactInfo );
+
+    StreamServiceKey streamServiceKey = StreamServiceKey.create( "DATA_SERVICE_ID", parameters, optimizations );
+    int streamServiceKeyValue = streamServiceKey.hashCode();
+    StreamServiceKey otherStreamServiceKey = StreamServiceKey.create( "DATA_SERVICE_ID", parameters, optimizations );
+
+    assertEquals( streamServiceKeyValue, otherStreamServiceKey.hashCode() );
+    assertEquals( 1, streamServiceKey.getParameters().size() );
+    assertEquals( Arrays.asList("AFTER"), streamServiceKey.getOptimizations() );
+    assertEquals( "DATA_SERVICE_ID", streamServiceKey.getDataServiceId() );
+
+    parameters.clear();
+    parameters.put( "key2", "value2" );
+
+    assertEquals( streamServiceKeyValue, streamServiceKey.hashCode() );
+    assertEquals( 1, streamServiceKey.getParameters().size() );
+
+    OptimizationImpactInfo optimizationImpactInfo2 = new OptimizationImpactInfo( "STEP_NAME_2" );
+    optimizationImpactInfo2.setQueryAfterOptimization( "AFTER2" );
+    optimizations.add( optimizationImpactInfo2 );
+
+    optimizationImpactInfo.setQueryAfterOptimization( "AFTER_CHANGED" );
+
+    assertEquals( streamServiceKeyValue, streamServiceKey.hashCode() );
+    assertEquals( 1, streamServiceKey.getParameters().size() );
+    assertEquals( Arrays.asList("AFTER"), streamServiceKey.getOptimizations() );
+    assertEquals( "DATA_SERVICE_ID", streamServiceKey.getDataServiceId() );
   }
 }

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/streaming/execution/StreamingGeneratedTransExecutionTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/streaming/execution/StreamingGeneratedTransExecutionTest.java
@@ -257,6 +257,17 @@ public class StreamingGeneratedTransExecutionTest {
     fail( "When the thrown exception is not a RuntimeException it should rethrow a RuntimeException" );
   }
 
+  @Test
+  public void testThreadNotInterrupted() throws KettleException {
+    when( rowProducer.putRowWait( any( RowMetaInterface.class ), any( Object[].class ), anyLong(),
+      any( TimeUnit.class ) ) ).thenReturn( false, true );
+
+    genTransExecutor.run();
+    genTransExecutor.getGeneratedDataObservable().onNext( rowIterator );
+    genTransExecutor.waitForGeneratedTransToFinnish();
+    verify( genTrans, times(1) ).startThreads( );
+  }
+
   private void verifyExecution( int numExecs ) throws Exception {
     verify( genTrans, times( numExecs ) ).cleanup( );
     verify( genTrans, times( numExecs ) ).prepareExecution( null );

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/streaming/execution/StreamingServiceTransExecutorTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/streaming/execution/StreamingServiceTransExecutorTest.java
@@ -36,6 +36,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.dataservice.DataServiceContext;
+import org.pentaho.di.trans.dataservice.DataServiceExecutor;
 import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
 import org.pentaho.di.trans.dataservice.streaming.StreamServiceKey;
 import org.pentaho.di.trans.dataservice.utils.DataServiceConstants;
@@ -47,7 +48,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -213,6 +216,27 @@ public class StreamingServiceTransExecutorTest {
 
     testBufferAux( rowMeta, data, false );
   }
+
+  @Test
+  public void testStartServiceDataServiceExecutorNull() throws Exception {
+    doReturn( null ).when( context ).getExecutor( any() );
+    RowMetaInterface rowMeta = serviceTrans.getTransMeta().getStepFields( MOCK_SERVICE_STEP_NAME );
+    Object[] data = new Object[] { 0 };
+    serviceExecutor.getBuffer( MOCK_QUERY, windowConsumer, MOCK_WINDOW_MODE_ROW_BASED, 1, 1, 10 );
+    testBufferAux( rowMeta, data, false );
+  }
+
+  @Test
+  public void testStartServiceDataServiceExecutor() throws Exception {
+    DataServiceExecutor dataServiceExecutor = mock( DataServiceExecutor.class );
+    doReturn( dataServiceExecutor ).when( context ).getExecutor( any() );
+    RowMetaInterface rowMeta = serviceTrans.getTransMeta().getStepFields( MOCK_SERVICE_STEP_NAME );
+    Object[] data = new Object[] { 0 };
+    serviceExecutor.getBuffer( MOCK_QUERY, windowConsumer, MOCK_WINDOW_MODE_ROW_BASED, 1, 1, 10 );
+    testBufferAux( rowMeta, data, false );
+    verify( dataServiceExecutor ).getParameters();
+  }
+
 
   private void testBufferAux() throws Exception {
     RowMetaInterface rowMeta = serviceTrans.getTransMeta().getStepFields( MOCK_SERVICE_STEP_NAME );


### PR DESCRIPTION
…time the pre window buffer (triggered by the "each" param) generates a window; The Stream Service Key should have the parameters created as a really immutable list; synchronize the creation and remove of stream elements from cache; Always copy the parameters into the service transformation when streaming