### PR TITLE
[PDI-18214] If SQL fails in transformations ran on the Pentaho Server…

### DIFF
--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/clients/AnnotationsQueryService.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/clients/AnnotationsQueryService.java
@@ -40,7 +40,6 @@ import org.pentaho.di.trans.dataservice.DataServiceExecutor;
 import org.pentaho.di.trans.dataservice.DataServiceMeta;
 import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
 import org.pentaho.di.trans.dataservice.resolvers.DataServiceResolver;
-import org.pentaho.di.trans.step.StepMetaDataCombi;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.osgi.metastore.locator.api.MetastoreLocator;
 


### PR DESCRIPTION
…, the database connections are not closed.

[CDA-243] With CDA the database sessions are not closed if SQL fails

Hold a reference to the created transformation in order to invoke its cleanup method when it was no more necessary.

@pentaho/tatooine @pentaho-lmartins @jpruiz114 