### PR TITLE
[PDI-19163] Upgraded mongo java driver version from 3.10.2 to 3.12.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <guava.version>17.0</guava.version>
     <jface.version>3.3.0-I20070606-0010</jface.version>
     <swt.version>4.6</swt.version>
-    <mongo.java.driver.version>3.10.2</mongo.java.driver.version>
+    <mongo.java.driver.version>3.12.10</mongo.java.driver.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <pentaho-modeler.version>9.3.0.0-SNAPSHOT</pentaho-modeler.version>
     <rxjava.version>2.2.3</rxjava.version>


### PR DESCRIPTION
Upgrading java mongo driver to the latest possible version without many changes in the code.