### PR TITLE
[BACKLOG-37434] Move metastore locator plugin access out of constructor

### DIFF
--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/clients/AnnotationsQueryService.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/clients/AnnotationsQueryService.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -61,14 +61,20 @@ public class AnnotationsQueryService implements Query.Service {
 
   // OSGi blueprint constructor
   public AnnotationsQueryService( final DataServiceResolver resolver ) {
-    try {
-      Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
-      metastoreLocator = metastoreLocators.stream().findFirst().get();
-    } catch ( Exception e ) {
-      LogChannel.GENERAL.logError( "Error getting MetastoreLocator", e );
-      throw new IllegalStateException( e );
-    }
     this.resolver = resolver;
+  }
+
+  protected MetastoreLocator getMetastoreLocator() {
+    if ( metastoreLocator == null ) {
+      try {
+        Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
+        metastoreLocator = metastoreLocators.stream().findFirst().get();
+      } catch ( Exception e ) {
+        LogChannel.GENERAL.logError( "Error getting MetastoreLocator", e );
+        throw new IllegalStateException( e );
+      }
+    }
+    return this.metastoreLocator;
   }
 
   @Override public Query prepareQuery( final String sql, final int maxRows, final Map<String, String> parameters )
@@ -139,7 +145,7 @@ public class AnnotationsQueryService implements Query.Service {
 
       disableAllUnrelatedHops( dataService.getStepname(), serviceTrans, false );
       final Trans trans = getTrans( serviceTrans );
-      trans.setMetaStore( metastoreLocator.getMetastore() );
+      trans.setMetaStore( getMetastoreLocator().getMetastore() );
       if ( !serviceTrans.getTransHopSteps( false ).isEmpty() ) {
         trans.prepareExecution( new String[] {} );
       }


### PR DESCRIPTION
to ensure plugin is loaded first.