### PR TITLE
[BACKLOG-38063] pdi-dataservice-server-plugin bundle was getting the

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -99,10 +99,6 @@
       <artifactId>pdi-dataservice-client-plugin-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -151,6 +147,7 @@
               org.pentaho.dictionary,
               org.pentaho.metaverse.api,
               org.pentaho.metaverse.api.*,
+              !javax.annotation,
               *
             </Import-Package>
           </instructions>


### PR DESCRIPTION
javax.annotation aka findbugs annotations from two different dependency chains in karaf; one from guava and one that it declared itself (using an older version).  Suppressing the self-declared dependency and allowing guava to pull in its version seems to have solved the problem.