### PR TITLE
[BACKLOG-42752]-Upgrading pdi-dataservice-server-plugin from Java EE to Jakarta-EE

### DIFF
--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/serialization/TransImportExtensionPointPlugin.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/serialization/TransImportExtensionPointPlugin.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,7 +22,7 @@
 package org.pentaho.di.trans.dataservice.serialization;
 
 import java.util.function.Function;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.extension.ExtensionPoint;
 import org.pentaho.di.core.extension.ExtensionPointInterface;

--- a/impl/src/main/java/org/pentaho/di/trans/dataservice/ui/DriverDetailsDialog.java
+++ b/impl/src/main/java/org/pentaho/di/trans/dataservice/ui/DriverDetailsDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -37,7 +37,7 @@ import org.pentaho.ui.xul.impl.AbstractXulLoader;
 import org.pentaho.ui.xul.swt.SwtXulRunner;
 import org.pentaho.ui.xul.swt.tags.SwtDialog;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.ResourceBundle;

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/BaseServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/BaseServletTest.java
@@ -40,9 +40,9 @@ import org.pentaho.di.www.CarteRequestHandler;
 import org.pentaho.di.www.SlaveServerConfig;
 import org.pentaho.di.www.TransformationMap;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Enumeration;

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServletTest.java
@@ -31,7 +31,7 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.dataservice.jdbc.ThinServiceInformation;
 import org.pentaho.di.trans.dataservice.jdbc.api.IThinServiceInformation;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
@@ -41,8 +41,8 @@ import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
 import org.pentaho.di.trans.dataservice.clients.Query;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>${servlet-api.version}</version>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${jakarta.servlet.version}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
[BACKLOG-42752]-Upgrading pdi-dataservice-server-plugin from Java EE to Jakarta-EE

[BACKLOG-42752]: https://hv-eng.atlassian.net/browse/BACKLOG-42752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ