### PR TITLE
[BACKLOG-43935]-Fix JDK21 test pipeline(test1) test case failures

### DIFF
--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
@@ -182,6 +182,8 @@ public class DataServiceClientTest extends BaseTest {
     try ( DataInputStream stream = client.query( TEST_SQL_QUERY, MAX_ROWS ) ) {
       assertThat( stream.read(), is( -1 ) );
     }
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log ).logError( any(), eq( expected ) );
   }
 
@@ -198,6 +200,8 @@ public class DataServiceClientTest extends BaseTest {
       WINDOW_MAX_SIZE ) ) {
       assertThat( stream.read(), is( -1 ) );
     }
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log ).logError( any(), eq( expected ) );
   }
 
@@ -258,6 +262,8 @@ public class DataServiceClientTest extends BaseTest {
 
     // Assert no errors thrown or logged
     assertThat( Futures.getChecked( queryFinished, IOException.class ), is( true ) );
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log, never() ).logError( anyString(), any( Throwable.class ) );
   }
 
@@ -288,6 +294,8 @@ public class DataServiceClientTest extends BaseTest {
 
     // Assert no errors thrown or logged
     assertThat( Futures.getChecked( queryFinished, IOException.class ), is( true ) );
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log, never() ).logError( anyString(), any( Throwable.class ) );
   }
 


### PR DESCRIPTION
[BACKLOG-43935]-Fix JDK21 test pipeline(test1) test case failures

[BACKLOG-43935]: https://hv-eng.atlassian.net/browse/BACKLOG-43935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ