### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17  

### DIFF
--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
@@ -51,6 +51,7 @@ import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -182,7 +183,7 @@ public class DataServiceClientTest extends BaseTest {
     try ( DataInputStream stream = client.query( TEST_SQL_QUERY, MAX_ROWS ) ) {
       assertThat( stream.read(), is( -1 ) );
     }
-    verify( log ).logError( any(), eq( expected ) );
+    verify( log ).logError( isNull(), eq( expected ) );
   }
 
   @Test
@@ -198,7 +199,7 @@ public class DataServiceClientTest extends BaseTest {
       WINDOW_MAX_SIZE ) ) {
       assertThat( stream.read(), is( -1 ) );
     }
-    verify( log ).logError( any(), eq( expected ) );
+    verify( log ).logError( isNull(), eq( expected ) );
   }
 
   @Test

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/clients/DataServiceClientTest.java
@@ -183,6 +183,8 @@ public class DataServiceClientTest extends BaseTest {
     try ( DataInputStream stream = client.query( TEST_SQL_QUERY, MAX_ROWS ) ) {
       assertThat( stream.read(), is( -1 ) );
     }
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log ).logError( isNull(), eq( expected ) );
   }
 
@@ -199,6 +201,8 @@ public class DataServiceClientTest extends BaseTest {
       WINDOW_MAX_SIZE ) ) {
       assertThat( stream.read(), is( -1 ) );
     }
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log ).logError( isNull(), eq( expected ) );
   }
 
@@ -259,6 +263,8 @@ public class DataServiceClientTest extends BaseTest {
 
     // Assert no errors thrown or logged
     assertThat( Futures.getChecked( queryFinished, IOException.class ), is( true ) );
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log, never() ).logError( anyString(), any( Throwable.class ) );
   }
 
@@ -289,6 +295,8 @@ public class DataServiceClientTest extends BaseTest {
 
     // Assert no errors thrown or logged
     assertThat( Futures.getChecked( queryFinished, IOException.class ), is( true ) );
+    // Holding the main thread for 2 seconds to avoid  race condition between the main thread and executor service thread created in DataServiceClient#query()
+    Thread.sleep( 2000 );
     verify( log, never() ).logError( anyString(), any( Throwable.class ) );
   }
 

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceRemapNoStepsDialogControllerTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceRemapNoStepsDialogControllerTest.java
@@ -29,7 +29,7 @@ public class DataServiceRemapNoStepsDialogControllerTest {
     SwtDialog dialog = mock( SwtDialog.class );
 
     DataServiceRemapNoStepsDialogController controller = spy( new DataServiceRemapNoStepsDialogController() );
-    Assert.hasText( controller.getName() );
+    Assert.hasText( controller.getName(), "" );
     doReturn( dialog ).when( controller ).getElementById( anyString() );
     controller.close();
     verify( dialog ).dispose();

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/BaseServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/BaseServletTest.java
@@ -31,9 +31,9 @@ import org.pentaho.di.www.CarteRequestHandler;
 import org.pentaho.di.www.SlaveServerConfig;
 import org.pentaho.di.www.TransformationMap;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Enumeration;

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServletTest.java
@@ -1,169 +1,169 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
-
-package org.pentaho.di.trans.dataservice.www;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.trans.dataservice.jdbc.ThinServiceInformation;
-import org.pentaho.di.trans.dataservice.jdbc.api.IThinServiceInformation;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-/**
- * @author bmorrise
- */
-public class ListDataServicesServletTest extends BaseServletTest {
-
-  private static final String SERVLET_STRING = "List data services";
-  private static final String CONTEXT_PATH = "/listServices";
-
-  @Mock private RowMetaInterface rowMetaInterface;
-  @Mock private SQLException sqlException;
-
-  private ListDataServicesServlet servlet;
-  private StringBuffer outputBuffer;
-  private String mockServiceName;
-
-  @Before
-  public void setUp() throws Exception {
-    mockServiceName = "mockServiceName";
-    servlet = new ListDataServicesServlet( client );
-    servlet.setJettyMode( true );
-    servlet.setup( transformationMap, null, null, null );
-
-    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
-
-    StringWriter out = new StringWriter();
-    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
-    when( response.getWriter() ).thenReturn( new PrintWriter( out ) );
-    when( rowMetaInterface.getMetaXML() ).thenReturn( "<rowMeta mock/>" );
-    when( client.getServiceInformation() ).thenReturn( ImmutableList.of( thinServiceInformation ) );
-    outputBuffer = out.getBuffer();
-  }
-
-  @Test
-  public void testDoGet() throws Exception {
-    servlet.service( request, response );
-    verifyRun();
-  }
-
-  @Test
-  public void testDoGetWithRequestParameter() throws Exception {
-    when( request.getParameter( anyString() ) ).thenReturn( "false" );
-    servlet.service( request, response );
-    verifyRun();
-  }
-
-  @Test
-  public void testDoPost() throws Exception {
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verifyRun();
-  }
-
-  private void verifyRun() throws Exception {
-    verify( response ).setStatus( HttpServletResponse.SC_OK );
-    verify( response ).setContentType( "text/xml; charset=utf-8" );
-    Pattern pattern = Pattern.compile( "<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\\s*<services>\\s*<service>\\s*<name>" + DATA_SERVICE_NAME + "<\\/name>\\s*<streaming>N</streaming>\\s*<rowMeta mock\\/>\\s*<\\/service>\\s*<\\/services>\\s*" );
-    assertTrue( pattern.matcher( outputBuffer ).matches() );
-  }
-
-  @Test
-  public void testFailure() throws SQLException, IOException {
-    when( client.getServiceInformation() ).thenThrow( sqlException );
-    when( carteRequest.respond( 500 ) ).thenReturn( carteResponse );
-
-    servlet.handleRequest( carteRequest );
-    verify( log ).logError( any( String.class ), any( SQLException.class ) );
-    verify( carteResponse ).withMessage( any( String.class ) );
-  }
-
-  @Test
-  public void testToString() {
-    assertEquals( SERVLET_STRING, servlet.toString() );
-  }
-
-  @Test
-  public void testGetService() {
-    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
-  }
-
-  @Test
-  public void testGetContextPath() {
-    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
-  }
-
-  @Test
-  public void testRequestGetServiceNameParameter() throws Exception {
-    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
-    builder.put( "serviceName", mockServiceName );
-    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
-    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
-    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
-    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
-    servlet.handleRequest( carteRequest );
-    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
-    verify( client, times( 0 ) ).getServiceInformation();
-  }
-
-  @Test
-  public void testRequestGetServiceNameAndStreamingParameter() throws Exception {
-    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
-    builder.put( "serviceName", mockServiceName );
-    builder.put( "streaming", "true" );
-    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
-    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
-    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
-    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
-    servlet.handleRequest( carteRequest );
-    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
-    verify( client, times( 0 ) ).getServiceInformation();
-  }
-
-  @Test
-  public void testRequestGetStreamingParameter() throws Exception {
-    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
-    builder.put( "streaming", "true" );
-    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, true, rowMetaInterface );
-    List<IThinServiceInformation> thinServiceInformationList = new ArrayList<>();
-    thinServiceInformationList.add( thinServiceInformation );
-
-    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
-    when( client.getServiceInformation() ).thenReturn( thinServiceInformationList );
-    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
-    servlet.handleRequest( carteRequest );
-    verify( client, times( 0 ) ).getServiceInformation( anyString() );
-    verify( client, times( 1 ) ).getServiceInformation();
-  }
-}
+///*! ******************************************************************************
+// *
+// * Pentaho
+// *
+// * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+// *
+// * Use of this software is governed by the Business Source License included
+// * in the LICENSE.TXT file.
+// *
+// * Change Date: 2029-07-20
+// ******************************************************************************/
+//
+//
+//package org.pentaho.di.trans.dataservice.www;
+//
+//import com.google.common.collect.ImmutableList;
+//import com.google.common.collect.ImmutableMultimap;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.mockito.Mock;
+//import org.pentaho.di.core.row.RowMetaInterface;
+//import org.pentaho.di.trans.dataservice.jdbc.ThinServiceInformation;
+//import org.pentaho.di.trans.dataservice.jdbc.api.IThinServiceInformation;
+//
+//import javax.servlet.http.HttpServletResponse;
+//import java.io.IOException;
+//import java.io.PrintWriter;
+//import java.io.StringWriter;
+//import java.sql.SQLException;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.regex.Pattern;
+//
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertTrue;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.lenient;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+///**
+// * @author bmorrise
+// */
+//public class ListDataServicesServletTest extends BaseServletTest {
+//
+//  private static final String SERVLET_STRING = "List data services";
+//  private static final String CONTEXT_PATH = "/listServices";
+//
+//  @Mock private RowMetaInterface rowMetaInterface;
+//  @Mock private SQLException sqlException;
+//
+//  private ListDataServicesServlet servlet;
+//  private StringBuffer outputBuffer;
+//  private String mockServiceName;
+//
+//  @Before
+//  public void setUp() throws Exception {
+//    mockServiceName = "mockServiceName";
+//    servlet = new ListDataServicesServlet( client );
+//    servlet.setJettyMode( true );
+//    servlet.setup( transformationMap, null, null, null );
+//
+//    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
+//
+//    StringWriter out = new StringWriter();
+//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
+//    when( response.getWriter() ).thenReturn( new PrintWriter( out ) );
+//    when( rowMetaInterface.getMetaXML() ).thenReturn( "<rowMeta mock/>" );
+//    when( client.getServiceInformation() ).thenReturn( ImmutableList.of( thinServiceInformation ) );
+//    outputBuffer = out.getBuffer();
+//  }
+//
+//  @Test
+//  public void testDoGet() throws Exception {
+//    servlet.service( request, response );
+//    verifyRun();
+//  }
+//
+//  @Test
+//  public void testDoGetWithRequestParameter() throws Exception {
+//    when( request.getParameter( anyString() ) ).thenReturn( "false" );
+//    servlet.service( request, response );
+//    verifyRun();
+//  }
+//
+//  @Test
+//  public void testDoPost() throws Exception {
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verifyRun();
+//  }
+//
+//  private void verifyRun() throws Exception {
+//    verify( response ).setStatus( HttpServletResponse.SC_OK );
+//    verify( response ).setContentType( "text/xml; charset=utf-8" );
+//    Pattern pattern = Pattern.compile( "<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\\s*<services>\\s*<service>\\s*<name>" + DATA_SERVICE_NAME + "<\\/name>\\s*<streaming>N</streaming>\\s*<rowMeta mock\\/>\\s*<\\/service>\\s*<\\/services>\\s*" );
+//    assertTrue( pattern.matcher( outputBuffer ).matches() );
+//  }
+//
+//  @Test
+//  public void testFailure() throws SQLException, IOException {
+//    when( client.getServiceInformation() ).thenThrow( sqlException );
+//    when( carteRequest.respond( 500 ) ).thenReturn( carteResponse );
+//
+//    servlet.handleRequest( carteRequest );
+//    verify( log ).logError( any( String.class ), any( SQLException.class ) );
+//    verify( carteResponse ).withMessage( any( String.class ) );
+//  }
+//
+//  @Test
+//  public void testToString() {
+//    assertEquals( SERVLET_STRING, servlet.toString() );
+//  }
+//
+//  @Test
+//  public void testGetService() {
+//    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
+//  }
+//
+//  @Test
+//  public void testGetContextPath() {
+//    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
+//  }
+//
+//  @Test
+//  public void testRequestGetServiceNameParameter() throws Exception {
+//    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+//    builder.put( "serviceName", mockServiceName );
+//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
+//    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
+//    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
+//    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
+//    servlet.handleRequest( carteRequest );
+//    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
+//    verify( client, times( 0 ) ).getServiceInformation();
+//  }
+//
+//  @Test
+//  public void testRequestGetServiceNameAndStreamingParameter() throws Exception {
+//    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+//    builder.put( "serviceName", mockServiceName );
+//    builder.put( "streaming", "true" );
+//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
+//    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
+//    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
+//    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
+//    servlet.handleRequest( carteRequest );
+//    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
+//    verify( client, times( 0 ) ).getServiceInformation();
+//  }
+//
+//  @Test
+//  public void testRequestGetStreamingParameter() throws Exception {
+//    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+//    builder.put( "streaming", "true" );
+//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, true, rowMetaInterface );
+//    List<IThinServiceInformation> thinServiceInformationList = new ArrayList<>();
+//    thinServiceInformationList.add( thinServiceInformation );
+//
+//    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
+//    when( client.getServiceInformation() ).thenReturn( thinServiceInformationList );
+//    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
+//    servlet.handleRequest( carteRequest );
+//    verify( client, times( 0 ) ).getServiceInformation( anyString() );
+//    verify( client, times( 1 ) ).getServiceInformation();
+//  }
+//}

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/ListDataServicesServletTest.java
@@ -1,169 +1,169 @@
-///*! ******************************************************************************
-// *
-// * Pentaho
-// *
-// * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
-// *
-// * Use of this software is governed by the Business Source License included
-// * in the LICENSE.TXT file.
-// *
-// * Change Date: 2029-07-20
-// ******************************************************************************/
-//
-//
-//package org.pentaho.di.trans.dataservice.www;
-//
-//import com.google.common.collect.ImmutableList;
-//import com.google.common.collect.ImmutableMultimap;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.mockito.Mock;
-//import org.pentaho.di.core.row.RowMetaInterface;
-//import org.pentaho.di.trans.dataservice.jdbc.ThinServiceInformation;
-//import org.pentaho.di.trans.dataservice.jdbc.api.IThinServiceInformation;
-//
-//import javax.servlet.http.HttpServletResponse;
-//import java.io.IOException;
-//import java.io.PrintWriter;
-//import java.io.StringWriter;
-//import java.sql.SQLException;
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.regex.Pattern;
-//
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertTrue;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.lenient;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-///**
-// * @author bmorrise
-// */
-//public class ListDataServicesServletTest extends BaseServletTest {
-//
-//  private static final String SERVLET_STRING = "List data services";
-//  private static final String CONTEXT_PATH = "/listServices";
-//
-//  @Mock private RowMetaInterface rowMetaInterface;
-//  @Mock private SQLException sqlException;
-//
-//  private ListDataServicesServlet servlet;
-//  private StringBuffer outputBuffer;
-//  private String mockServiceName;
-//
-//  @Before
-//  public void setUp() throws Exception {
-//    mockServiceName = "mockServiceName";
-//    servlet = new ListDataServicesServlet( client );
-//    servlet.setJettyMode( true );
-//    servlet.setup( transformationMap, null, null, null );
-//
-//    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
-//
-//    StringWriter out = new StringWriter();
-//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
-//    when( response.getWriter() ).thenReturn( new PrintWriter( out ) );
-//    when( rowMetaInterface.getMetaXML() ).thenReturn( "<rowMeta mock/>" );
-//    when( client.getServiceInformation() ).thenReturn( ImmutableList.of( thinServiceInformation ) );
-//    outputBuffer = out.getBuffer();
-//  }
-//
-//  @Test
-//  public void testDoGet() throws Exception {
-//    servlet.service( request, response );
-//    verifyRun();
-//  }
-//
-//  @Test
-//  public void testDoGetWithRequestParameter() throws Exception {
-//    when( request.getParameter( anyString() ) ).thenReturn( "false" );
-//    servlet.service( request, response );
-//    verifyRun();
-//  }
-//
-//  @Test
-//  public void testDoPost() throws Exception {
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verifyRun();
-//  }
-//
-//  private void verifyRun() throws Exception {
-//    verify( response ).setStatus( HttpServletResponse.SC_OK );
-//    verify( response ).setContentType( "text/xml; charset=utf-8" );
-//    Pattern pattern = Pattern.compile( "<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\\s*<services>\\s*<service>\\s*<name>" + DATA_SERVICE_NAME + "<\\/name>\\s*<streaming>N</streaming>\\s*<rowMeta mock\\/>\\s*<\\/service>\\s*<\\/services>\\s*" );
-//    assertTrue( pattern.matcher( outputBuffer ).matches() );
-//  }
-//
-//  @Test
-//  public void testFailure() throws SQLException, IOException {
-//    when( client.getServiceInformation() ).thenThrow( sqlException );
-//    when( carteRequest.respond( 500 ) ).thenReturn( carteResponse );
-//
-//    servlet.handleRequest( carteRequest );
-//    verify( log ).logError( any( String.class ), any( SQLException.class ) );
-//    verify( carteResponse ).withMessage( any( String.class ) );
-//  }
-//
-//  @Test
-//  public void testToString() {
-//    assertEquals( SERVLET_STRING, servlet.toString() );
-//  }
-//
-//  @Test
-//  public void testGetService() {
-//    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
-//  }
-//
-//  @Test
-//  public void testGetContextPath() {
-//    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
-//  }
-//
-//  @Test
-//  public void testRequestGetServiceNameParameter() throws Exception {
-//    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
-//    builder.put( "serviceName", mockServiceName );
-//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
-//    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
-//    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
-//    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
-//    servlet.handleRequest( carteRequest );
-//    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
-//    verify( client, times( 0 ) ).getServiceInformation();
-//  }
-//
-//  @Test
-//  public void testRequestGetServiceNameAndStreamingParameter() throws Exception {
-//    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
-//    builder.put( "serviceName", mockServiceName );
-//    builder.put( "streaming", "true" );
-//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
-//    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
-//    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
-//    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
-//    servlet.handleRequest( carteRequest );
-//    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
-//    verify( client, times( 0 ) ).getServiceInformation();
-//  }
-//
-//  @Test
-//  public void testRequestGetStreamingParameter() throws Exception {
-//    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
-//    builder.put( "streaming", "true" );
-//    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, true, rowMetaInterface );
-//    List<IThinServiceInformation> thinServiceInformationList = new ArrayList<>();
-//    thinServiceInformationList.add( thinServiceInformation );
-//
-//    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
-//    when( client.getServiceInformation() ).thenReturn( thinServiceInformationList );
-//    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
-//    servlet.handleRequest( carteRequest );
-//    verify( client, times( 0 ) ).getServiceInformation( anyString() );
-//    verify( client, times( 1 ) ).getServiceInformation();
-//  }
-//}
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.di.trans.dataservice.www;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.dataservice.jdbc.ThinServiceInformation;
+import org.pentaho.di.trans.dataservice.jdbc.api.IThinServiceInformation;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author bmorrise
+ */
+public class ListDataServicesServletTest extends BaseServletTest {
+
+  private static final String SERVLET_STRING = "List data services";
+  private static final String CONTEXT_PATH = "/listServices";
+
+  @Mock private RowMetaInterface rowMetaInterface;
+  @Mock private SQLException sqlException;
+
+  private ListDataServicesServlet servlet;
+  private StringBuffer outputBuffer;
+  private String mockServiceName;
+
+  @Before
+  public void setUp() throws Exception {
+    mockServiceName = "mockServiceName";
+    servlet = new ListDataServicesServlet( client );
+    servlet.setJettyMode( true );
+    servlet.setup( transformationMap, null, null, null );
+
+    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
+
+    StringWriter out = new StringWriter();
+    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
+    when( response.getWriter() ).thenReturn( new PrintWriter( out ) );
+    when( rowMetaInterface.getMetaXML() ).thenReturn( "<rowMeta mock/>" );
+    when( client.getServiceInformation() ).thenReturn( ImmutableList.of( thinServiceInformation ) );
+    outputBuffer = out.getBuffer();
+  }
+
+  @Test
+  public void testDoGet() throws Exception {
+    servlet.service( request, response );
+    verifyRun();
+  }
+
+  @Test
+  public void testDoGetWithRequestParameter() throws Exception {
+    when( request.getParameter( anyString() ) ).thenReturn( "false" );
+    servlet.service( request, response );
+    verifyRun();
+  }
+
+  @Test
+  public void testDoPost() throws Exception {
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verifyRun();
+  }
+
+  private void verifyRun() throws Exception {
+    verify( response ).setStatus( HttpServletResponse.SC_OK );
+    verify( response ).setContentType( "text/xml; charset=utf-8" );
+    Pattern pattern = Pattern.compile( "<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\\s*<services>\\s*<service>\\s*<name>" + DATA_SERVICE_NAME + "<\\/name>\\s*<streaming>N</streaming>\\s*<rowMeta mock\\/>\\s*<\\/service>\\s*<\\/services>\\s*" );
+    assertTrue( pattern.matcher( outputBuffer ).matches() );
+  }
+
+  @Test
+  public void testFailure() throws SQLException, IOException {
+    when( client.getServiceInformation() ).thenThrow( sqlException );
+    when( carteRequest.respond( 500 ) ).thenReturn( carteResponse );
+
+    servlet.handleRequest( carteRequest );
+    verify( log ).logError( any( String.class ), any( SQLException.class ) );
+    verify( carteResponse ).withMessage( any( String.class ) );
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals( SERVLET_STRING, servlet.toString() );
+  }
+
+  @Test
+  public void testGetService() {
+    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
+  }
+
+  @Test
+  public void testGetContextPath() {
+    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
+  }
+
+  @Test
+  public void testRequestGetServiceNameParameter() throws Exception {
+    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+    builder.put( "serviceName", mockServiceName );
+    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
+    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
+    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
+    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
+    servlet.handleRequest( carteRequest );
+    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
+    verify( client, times( 0 ) ).getServiceInformation();
+  }
+
+  @Test
+  public void testRequestGetServiceNameAndStreamingParameter() throws Exception {
+    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+    builder.put( "serviceName", mockServiceName );
+    builder.put( "streaming", "true" );
+    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, false, rowMetaInterface );
+    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
+    when( client.getServiceInformation( mockServiceName ) ).thenReturn( thinServiceInformation );
+    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
+    servlet.handleRequest( carteRequest );
+    verify( client, times( 1 ) ).getServiceInformation( mockServiceName );
+    verify( client, times( 0 ) ).getServiceInformation();
+  }
+
+  @Test
+  public void testRequestGetStreamingParameter() throws Exception {
+    ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+    builder.put( "streaming", "true" );
+    ThinServiceInformation thinServiceInformation = new ThinServiceInformation( DATA_SERVICE_NAME, true, rowMetaInterface );
+    List<IThinServiceInformation> thinServiceInformationList = new ArrayList<>();
+    thinServiceInformationList.add( thinServiceInformation );
+
+    when( carteRequest.getParameters() ).thenReturn( builder.build().asMap() );
+    when( client.getServiceInformation() ).thenReturn( thinServiceInformationList );
+    when( carteRequest.respond( 200 ) ).thenReturn( carteResponse );
+    servlet.handleRequest( carteRequest );
+    verify( client, times( 0 ) ).getServiceInformation( anyString() );
+    verify( client, times( 1 ) ).getServiceInformation();
+  }
+}

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
@@ -1,382 +1,382 @@
-/*! ******************************************************************************
- *
- * Pentaho
- *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
- *
- * Use of this software is governed by the Business Source License included
- * in the LICENSE.TXT file.
- *
- * Change Date: 2029-07-20
- ******************************************************************************/
-
-
-package org.pentaho.di.trans.dataservice.www;
-
-import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
-import org.apache.commons.lang.StringUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.ArgumentCaptor;
-import org.mockito.hamcrest.MockitoHamcrest;
-import org.pentaho.di.core.sql.SQL;
-import org.pentaho.di.trans.Trans;
-import org.pentaho.di.trans.TransConfiguration;
-import org.pentaho.di.trans.TransMeta;
-import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
-import org.pentaho.di.trans.dataservice.clients.Query;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
-import java.io.File;
-import java.io.IOException;
-import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-/**
- * @author bmorrise nhudak
- */
-public class TransDataServletTest extends BaseServletTest {
-
-  private static final String BAD_CONTEXT_PATH = "/badsql";
-  private static final String CONTEXT_PATH = "/sql";
-  private static final String HEADER_SQL = "SQL";
-  private static final String HEADER_MAX_ROWS = "MaxRows";
-  private static final String HEADER_WINDOW_MODE = "WindowMode";
-  private static final String HEADER_WINDOW_SIZE = "WindowSize";
-  private static final String HEADER_WINDOW_EVERY = "WindowEvery";
-  private static final String HEADER_WINDOW_LIMIT = "WindowLimit";
-  private static final String TEST_DATA_SERVICE_NAME = "dataservice_test";
-  private static final String TEST_SQL_QUERY = "SELECT * FROM dataservice_test";
-  private static final String TEST_LARGE_SQL_QUERY = TEST_SQL_QUERY + " /" + StringUtils.repeat( "*", 8000 ) + "/";
-  private static final String DEBUG_TRANS_FILE = "debugtransfile";
-  private static final String TEST_MAX_ROWS = "100";
-  private static final String TEST_WINDOW_MODE_ROW = IDataServiceClientService.StreamingMode.ROW_BASED.toString();
-  private static final String TEST_WINDOW_MODE_TIME = IDataServiceClientService.StreamingMode.TIME_BASED.toString();
-  private static final String TEST_WINDOW_SIZE = "1";
-  private static final String TEST_WINDOW_EVERY = "2";
-  private static final String TEST_WINDOW_LIMIT = "3";
-  private static final String PARAM_DEBUG_TRANS = "debugtrans";
-  private static final String SERVLET_STRING = "Get data from a data service";
-  private static final String serviceTransUUID = UUID.randomUUID().toString();
-  private static final String genTransUUID = UUID.randomUUID().toString();
-  private static final String GEN_TRANS_XML = "<trans name=genTrans mock/>";
-
-  private static final int DEFAULT_WINDOW_MAX_ROWS = 50;
-  private static final long DEFAULT_WINDOW_MAX_TIME = 1000;
-
-  @Rule public TemporaryFolder fs = new TemporaryFolder();
-
-  private Trans serviceTrans;
-
-  private TransMeta genTransMeta;
-
-  private Trans genTrans;
-
-  private TransDataServlet servlet;
-
-  private File debugTrans;
-
-  @Before
-  public void setUp() throws Exception {
-//    when( context.getLogChannel() ).thenReturn( log );
-    serviceTrans = new Trans( transMeta );
-    serviceTrans.setContainerObjectId( serviceTransUUID );
-    genTransMeta = createTransMeta( TEST_SQL_QUERY );
-    genTrans = new Trans( genTransMeta );
-    genTrans.setContainerObjectId( genTransUUID );
-
-    doReturn( GEN_TRANS_XML ).when( genTransMeta ).getXML();
-
-    servlet = new TransDataServlet( client );
-    servlet.setJettyMode( true );
-    servlet.setup( transformationMap, null, null, null );
-
-    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
-    debugTrans = fs.newFile( DEBUG_TRANS_FILE );
-  }
-
-  @Test
-  public void testDoPut() throws Exception {
-    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-    parameters.put( "PARAMETER_FOO", "BAR" );
-    parameters.put( PARAM_DEBUG_TRANS, debugTrans.getPath() );
-
-    Query query = mock( Query.class );
-    doReturn( query )
-      .when( client )
-      .prepareQuery( TEST_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.of( "FOO", "BAR" ) );
-    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-
-//    when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-
-    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
-    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
-    verify( request, never() ).getParameter( HEADER_WINDOW_MODE );
-    verify( request, never() ).getParameter( HEADER_WINDOW_SIZE );
-    verify( request, never() ).getParameter( HEADER_WINDOW_EVERY );
-    verify( request, never() ).getParameter( HEADER_WINDOW_LIMIT );
-
-    verify( response ).setStatus( HttpServletResponse.SC_OK );
-    verify( response ).setContentType( "binary/jdbc" );
-    verify( query ).writeTo( outputStream );
-
-    verify( transformationMap ).addTransformation(
-      eq( DATA_SERVICE_NAME ),
-      eq( serviceTransUUID ),
-      eq( serviceTrans ),
-      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( transMeta ) ) )
-    );
-    verify( transformationMap ).addTransformation(
-      eq( TEST_SQL_QUERY ),
-      eq( genTransUUID ),
-      eq( genTrans ),
-      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( genTransMeta ) ) )
-    );
-    Files.readLines( debugTrans, Charsets.UTF_8 ).contains( GEN_TRANS_XML );
-  }
-
-  @Test
-  public void testStreamingHeader() throws Exception {
-    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
-    headers.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
-    headers.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
-    headers.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
-
-    Query query = mock( Query.class );
-    lenient().doReturn( query )
-      .when( client )
-      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
-        Long.valueOf( TEST_WINDOW_SIZE ),
-        Long.valueOf( TEST_WINDOW_EVERY ),
-        Long.valueOf( TEST_WINDOW_LIMIT ),
-        ImmutableMap.of( "FOO", "BAR" ) );
-    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-
-    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
-    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
-    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_MODE );
-    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_SIZE );
-    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_EVERY );
-    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_LIMIT );
-    verify( request, times( 1 ) ).getHeader( HEADER_SQL );
-    verify( request, times( 1 ) ).getHeader( HEADER_MAX_ROWS );
-    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_MODE );
-    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_SIZE );
-    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_EVERY );
-    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_LIMIT );
-  }
-
-  @Test
-  public void testStreamingParameters() throws Exception {
-    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-    parameters.put( HEADER_SQL, TEST_SQL_QUERY );
-    parameters.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
-    parameters.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
-    parameters.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
-    parameters.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
-
-    Query query = mock( Query.class );
-    lenient().doReturn( query )
-      .when( client )
-      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
-        Long.valueOf( TEST_WINDOW_SIZE ),
-        Long.valueOf( TEST_WINDOW_EVERY ),
-        Long.valueOf( TEST_WINDOW_LIMIT ),
-        ImmutableMap.of( "FOO", "BAR" ) );
-    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-
-    verify( request, times( 2 ) ).getParameter( HEADER_SQL );
-    verify( request, times( 2 ) ).getParameter( HEADER_MAX_ROWS );
-    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_MODE );
-    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_SIZE );
-    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_EVERY );
-    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_LIMIT );
-    verify( request, never() ).getHeader( HEADER_SQL );
-    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
-    verify( request, never() ).getHeader( HEADER_WINDOW_MODE );
-    verify( request, never() ).getHeader( HEADER_WINDOW_SIZE );
-    verify( request, never() ).getHeader( HEADER_WINDOW_EVERY );
-    verify( request, never() ).getHeader( HEADER_WINDOW_LIMIT );
-  }
-
-  @Test
-  public void testStreamingRowBasedDefaultParams() throws Exception {
-    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_ROW );
-
-    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
-    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
-
-    Query query = mock( Query.class );
-    lenient().doReturn( query )
-      .when( client )
-      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
-        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-        ImmutableMap.of( "FOO", "BAR" ) );
-    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-  }
-
-  @Test
-  public void testStreamingDefaultModeDefauldParams() throws Exception {
-    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-
-    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
-    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
-
-    Query query = mock( Query.class );
-    lenient().doReturn( query )
-      .when( client )
-      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
-        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-        ImmutableMap.of( "FOO", "BAR" ) );
-    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-  }
-
-  @Test
-  public void testStreamingTimeBasedModeDefauldParams() throws Exception {
-    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
-
-    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
-    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
-
-    Query query = mock( Query.class );
-    lenient().doReturn( query )
-      .when( client )
-      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
-        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-        ImmutableMap.of( "FOO", "BAR" ) );
-    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-  }
-
-  @Test
-  public void testLargeSQLQuery() throws Exception {
-    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-    parameters.put( HEADER_SQL, TEST_LARGE_SQL_QUERY );
-
-    Query query = mock( Query.class );
-    doReturn( query )
-        .when( client )
-        .prepareQuery( TEST_LARGE_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.<String, String>of() );
-    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-
-    lenient().when( request.getMethod() ).thenReturn( "POST" );
-    servlet.service( request, response );
-    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-
-    verify( request, never() ).getHeader( HEADER_SQL );
-    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
-  }
-
-  @Test
-  public void testMultipleParamValues() throws IOException, ServletException {
-    parameters.put( "PARAMETER_foo", "bar" );
-    parameters.put( "PARAMETER_foo", "baz" );
-    parameters.put( "SQL", "select * from dual" );
-    servlet.service( request, response );
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass( String.class );
-    verify( log ).logDetailed( captor.capture() );
-    assertThat( captor.getValue(), containsString( "PARAMETER_foo" ) );
-  }
-
-  @Test
-  public void testDoGetException() throws Exception {
-    lenient().when( factory.createBuilder( any( SQL.class ) ) ).thenThrow( new MetaStoreException( "expected" ) );
-
-    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-    servlet.service( request, response );
-
-    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
-  }
-
-  @Test
-  public void testDoGetMissingSQL() throws Exception {
-    headers.removeAll( HEADER_SQL );
-    servlet.service( request, response );
-
-    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
-    verify( client, times( 1 ) ).getLogChannel();
-  }
-
-  @Test
-  public void testDoGetBadPath() throws Exception {
-    when( request.getContextPath() ).thenReturn( BAD_CONTEXT_PATH );
-
-    servlet.service( request, response );
-
-    verify( response, never() ).setStatus( HttpServletResponse.SC_OK );
-  }
-
-  @Test
-  public void testToString() {
-    assertEquals( SERVLET_STRING, servlet.toString() );
-  }
-
-  @Test
-  public void testGetService() {
-    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
-  }
-
-  @Test
-  public void testGetContextPath() {
-    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
-  }
-}
+///*! ******************************************************************************
+// *
+// * Pentaho
+// *
+// * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+// *
+// * Use of this software is governed by the Business Source License included
+// * in the LICENSE.TXT file.
+// *
+// * Change Date: 2029-07-20
+// ******************************************************************************/
+//
+//
+//package org.pentaho.di.trans.dataservice.www;
+//
+//import com.google.common.base.Charsets;
+//import com.google.common.collect.ImmutableList;
+//import com.google.common.collect.ImmutableMap;
+//import com.google.common.io.Files;
+//import org.apache.commons.lang.StringUtils;
+//import org.junit.Before;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.junit.rules.TemporaryFolder;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.hamcrest.MockitoHamcrest;
+//import org.pentaho.di.core.sql.SQL;
+//import org.pentaho.di.trans.Trans;
+//import org.pentaho.di.trans.TransConfiguration;
+//import org.pentaho.di.trans.TransMeta;
+//import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
+//import org.pentaho.di.trans.dataservice.clients.Query;
+//import org.pentaho.metastore.api.exceptions.MetaStoreException;
+//
+//import javax.servlet.ServletException;
+//import javax.servlet.http.HttpServletResponse;
+//import java.io.File;
+//import java.io.IOException;
+//import java.util.UUID;
+//
+//import static org.hamcrest.CoreMatchers.containsString;
+//import static org.hamcrest.Matchers.hasProperty;
+//import static org.hamcrest.Matchers.is;
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertThat;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.any;
+//import static org.mockito.Mockito.anyString;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.lenient;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+///**
+// * @author bmorrise nhudak
+// */
+//public class TransDataServletTest extends BaseServletTest {
+//
+//  private static final String BAD_CONTEXT_PATH = "/badsql";
+//  private static final String CONTEXT_PATH = "/sql";
+//  private static final String HEADER_SQL = "SQL";
+//  private static final String HEADER_MAX_ROWS = "MaxRows";
+//  private static final String HEADER_WINDOW_MODE = "WindowMode";
+//  private static final String HEADER_WINDOW_SIZE = "WindowSize";
+//  private static final String HEADER_WINDOW_EVERY = "WindowEvery";
+//  private static final String HEADER_WINDOW_LIMIT = "WindowLimit";
+//  private static final String TEST_DATA_SERVICE_NAME = "dataservice_test";
+//  private static final String TEST_SQL_QUERY = "SELECT * FROM dataservice_test";
+//  private static final String TEST_LARGE_SQL_QUERY = TEST_SQL_QUERY + " /" + StringUtils.repeat( "*", 8000 ) + "/";
+//  private static final String DEBUG_TRANS_FILE = "debugtransfile";
+//  private static final String TEST_MAX_ROWS = "100";
+//  private static final String TEST_WINDOW_MODE_ROW = IDataServiceClientService.StreamingMode.ROW_BASED.toString();
+//  private static final String TEST_WINDOW_MODE_TIME = IDataServiceClientService.StreamingMode.TIME_BASED.toString();
+//  private static final String TEST_WINDOW_SIZE = "1";
+//  private static final String TEST_WINDOW_EVERY = "2";
+//  private static final String TEST_WINDOW_LIMIT = "3";
+//  private static final String PARAM_DEBUG_TRANS = "debugtrans";
+//  private static final String SERVLET_STRING = "Get data from a data service";
+//  private static final String serviceTransUUID = UUID.randomUUID().toString();
+//  private static final String genTransUUID = UUID.randomUUID().toString();
+//  private static final String GEN_TRANS_XML = "<trans name=genTrans mock/>";
+//
+//  private static final int DEFAULT_WINDOW_MAX_ROWS = 50;
+//  private static final long DEFAULT_WINDOW_MAX_TIME = 1000;
+//
+//  @Rule public TemporaryFolder fs = new TemporaryFolder();
+//
+//  private Trans serviceTrans;
+//
+//  private TransMeta genTransMeta;
+//
+//  private Trans genTrans;
+//
+//  private TransDataServlet servlet;
+//
+//  private File debugTrans;
+//
+//  @Before
+//  public void setUp() throws Exception {
+////    when( context.getLogChannel() ).thenReturn( log );
+//    serviceTrans = new Trans( transMeta );
+//    serviceTrans.setContainerObjectId( serviceTransUUID );
+//    genTransMeta = createTransMeta( TEST_SQL_QUERY );
+//    genTrans = new Trans( genTransMeta );
+//    genTrans.setContainerObjectId( genTransUUID );
+//
+//    doReturn( GEN_TRANS_XML ).when( genTransMeta ).getXML();
+//
+//    servlet = new TransDataServlet( client );
+//    servlet.setJettyMode( true );
+//    servlet.setup( transformationMap, null, null, null );
+//
+//    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
+//    debugTrans = fs.newFile( DEBUG_TRANS_FILE );
+//  }
+//
+//  @Test
+//  public void testDoPut() throws Exception {
+//    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+//    parameters.put( "PARAMETER_FOO", "BAR" );
+//    parameters.put( PARAM_DEBUG_TRANS, debugTrans.getPath() );
+//
+//    Query query = mock( Query.class );
+//    doReturn( query )
+//      .when( client )
+//      .prepareQuery( TEST_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.of( "FOO", "BAR" ) );
+//    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//
+////    when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//
+//    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
+//    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
+//    verify( request, never() ).getParameter( HEADER_WINDOW_MODE );
+//    verify( request, never() ).getParameter( HEADER_WINDOW_SIZE );
+//    verify( request, never() ).getParameter( HEADER_WINDOW_EVERY );
+//    verify( request, never() ).getParameter( HEADER_WINDOW_LIMIT );
+//
+//    verify( response ).setStatus( HttpServletResponse.SC_OK );
+//    verify( response ).setContentType( "binary/jdbc" );
+//    verify( query ).writeTo( outputStream );
+//
+//    verify( transformationMap ).addTransformation(
+//      eq( DATA_SERVICE_NAME ),
+//      eq( serviceTransUUID ),
+//      eq( serviceTrans ),
+//      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( transMeta ) ) )
+//    );
+//    verify( transformationMap ).addTransformation(
+//      eq( TEST_SQL_QUERY ),
+//      eq( genTransUUID ),
+//      eq( genTrans ),
+//      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( genTransMeta ) ) )
+//    );
+//    Files.readLines( debugTrans, Charsets.UTF_8 ).contains( GEN_TRANS_XML );
+//  }
+//
+//  @Test
+//  public void testStreamingHeader() throws Exception {
+//    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+//    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
+//    headers.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
+//    headers.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
+//    headers.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
+//
+//    Query query = mock( Query.class );
+//    lenient().doReturn( query )
+//      .when( client )
+//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
+//        Long.valueOf( TEST_WINDOW_SIZE ),
+//        Long.valueOf( TEST_WINDOW_EVERY ),
+//        Long.valueOf( TEST_WINDOW_LIMIT ),
+//        ImmutableMap.of( "FOO", "BAR" ) );
+//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+//
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//
+//    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
+//    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
+//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_MODE );
+//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_SIZE );
+//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_EVERY );
+//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_LIMIT );
+//    verify( request, times( 1 ) ).getHeader( HEADER_SQL );
+//    verify( request, times( 1 ) ).getHeader( HEADER_MAX_ROWS );
+//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_MODE );
+//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_SIZE );
+//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_EVERY );
+//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_LIMIT );
+//  }
+//
+//  @Test
+//  public void testStreamingParameters() throws Exception {
+//    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+//    parameters.put( HEADER_SQL, TEST_SQL_QUERY );
+//    parameters.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
+//    parameters.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
+//    parameters.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
+//    parameters.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
+//
+//    Query query = mock( Query.class );
+//    lenient().doReturn( query )
+//      .when( client )
+//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
+//        Long.valueOf( TEST_WINDOW_SIZE ),
+//        Long.valueOf( TEST_WINDOW_EVERY ),
+//        Long.valueOf( TEST_WINDOW_LIMIT ),
+//        ImmutableMap.of( "FOO", "BAR" ) );
+//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+//
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//
+//    verify( request, times( 2 ) ).getParameter( HEADER_SQL );
+//    verify( request, times( 2 ) ).getParameter( HEADER_MAX_ROWS );
+//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_MODE );
+//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_SIZE );
+//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_EVERY );
+//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_LIMIT );
+//    verify( request, never() ).getHeader( HEADER_SQL );
+//    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
+//    verify( request, never() ).getHeader( HEADER_WINDOW_MODE );
+//    verify( request, never() ).getHeader( HEADER_WINDOW_SIZE );
+//    verify( request, never() ).getHeader( HEADER_WINDOW_EVERY );
+//    verify( request, never() ).getHeader( HEADER_WINDOW_LIMIT );
+//  }
+//
+//  @Test
+//  public void testStreamingRowBasedDefaultParams() throws Exception {
+//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+//    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_ROW );
+//
+//    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
+//    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
+//
+//    Query query = mock( Query.class );
+//    lenient().doReturn( query )
+//      .when( client )
+//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
+//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+//        ImmutableMap.of( "FOO", "BAR" ) );
+//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+//
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//  }
+//
+//  @Test
+//  public void testStreamingDefaultModeDefauldParams() throws Exception {
+//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+//
+//    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
+//    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
+//
+//    Query query = mock( Query.class );
+//    lenient().doReturn( query )
+//      .when( client )
+//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
+//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+//        ImmutableMap.of( "FOO", "BAR" ) );
+//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+//
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//  }
+//
+//  @Test
+//  public void testStreamingTimeBasedModeDefauldParams() throws Exception {
+//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+//    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
+//
+//    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
+//    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
+//
+//    Query query = mock( Query.class );
+//    lenient().doReturn( query )
+//      .when( client )
+//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
+//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+//        ImmutableMap.of( "FOO", "BAR" ) );
+//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+//
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//  }
+//
+//  @Test
+//  public void testLargeSQLQuery() throws Exception {
+//    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+//    parameters.put( HEADER_SQL, TEST_LARGE_SQL_QUERY );
+//
+//    Query query = mock( Query.class );
+//    doReturn( query )
+//        .when( client )
+//        .prepareQuery( TEST_LARGE_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.<String, String>of() );
+//    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+//
+//    lenient().when( request.getMethod() ).thenReturn( "POST" );
+//    servlet.service( request, response );
+//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+//
+//    verify( request, never() ).getHeader( HEADER_SQL );
+//    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
+//  }
+//
+//  @Test
+//  public void testMultipleParamValues() throws IOException, ServletException {
+//    parameters.put( "PARAMETER_foo", "bar" );
+//    parameters.put( "PARAMETER_foo", "baz" );
+//    parameters.put( "SQL", "select * from dual" );
+//    servlet.service( request, response );
+//    ArgumentCaptor<String> captor = ArgumentCaptor.forClass( String.class );
+//    verify( log ).logDetailed( captor.capture() );
+//    assertThat( captor.getValue(), containsString( "PARAMETER_foo" ) );
+//  }
+//
+//  @Test
+//  public void testDoGetException() throws Exception {
+//    lenient().when( factory.createBuilder( any( SQL.class ) ) ).thenThrow( new MetaStoreException( "expected" ) );
+//
+//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+//    servlet.service( request, response );
+//
+//    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
+//  }
+//
+//  @Test
+//  public void testDoGetMissingSQL() throws Exception {
+//    headers.removeAll( HEADER_SQL );
+//    servlet.service( request, response );
+//
+//    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
+//    verify( client, times( 1 ) ).getLogChannel();
+//  }
+//
+//  @Test
+//  public void testDoGetBadPath() throws Exception {
+//    when( request.getContextPath() ).thenReturn( BAD_CONTEXT_PATH );
+//
+//    servlet.service( request, response );
+//
+//    verify( response, never() ).setStatus( HttpServletResponse.SC_OK );
+//  }
+//
+//  @Test
+//  public void testToString() {
+//    assertEquals( SERVLET_STRING, servlet.toString() );
+//  }
+//
+//  @Test
+//  public void testGetService() {
+//    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
+//  }
+//
+//  @Test
+//  public void testGetContextPath() {
+//    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
+//  }
+//}

--- a/impl/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
+++ b/impl/src/test/java/org/pentaho/di/trans/dataservice/www/TransDataServletTest.java
@@ -1,382 +1,382 @@
-///*! ******************************************************************************
-// *
-// * Pentaho
-// *
-// * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
-// *
-// * Use of this software is governed by the Business Source License included
-// * in the LICENSE.TXT file.
-// *
-// * Change Date: 2029-07-20
-// ******************************************************************************/
-//
-//
-//package org.pentaho.di.trans.dataservice.www;
-//
-//import com.google.common.base.Charsets;
-//import com.google.common.collect.ImmutableList;
-//import com.google.common.collect.ImmutableMap;
-//import com.google.common.io.Files;
-//import org.apache.commons.lang.StringUtils;
-//import org.junit.Before;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.rules.TemporaryFolder;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.hamcrest.MockitoHamcrest;
-//import org.pentaho.di.core.sql.SQL;
-//import org.pentaho.di.trans.Trans;
-//import org.pentaho.di.trans.TransConfiguration;
-//import org.pentaho.di.trans.TransMeta;
-//import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
-//import org.pentaho.di.trans.dataservice.clients.Query;
-//import org.pentaho.metastore.api.exceptions.MetaStoreException;
-//
-//import javax.servlet.ServletException;
-//import javax.servlet.http.HttpServletResponse;
-//import java.io.File;
-//import java.io.IOException;
-//import java.util.UUID;
-//
-//import static org.hamcrest.CoreMatchers.containsString;
-//import static org.hamcrest.Matchers.hasProperty;
-//import static org.hamcrest.Matchers.is;
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertThat;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.any;
-//import static org.mockito.Mockito.anyString;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.lenient;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-///**
-// * @author bmorrise nhudak
-// */
-//public class TransDataServletTest extends BaseServletTest {
-//
-//  private static final String BAD_CONTEXT_PATH = "/badsql";
-//  private static final String CONTEXT_PATH = "/sql";
-//  private static final String HEADER_SQL = "SQL";
-//  private static final String HEADER_MAX_ROWS = "MaxRows";
-//  private static final String HEADER_WINDOW_MODE = "WindowMode";
-//  private static final String HEADER_WINDOW_SIZE = "WindowSize";
-//  private static final String HEADER_WINDOW_EVERY = "WindowEvery";
-//  private static final String HEADER_WINDOW_LIMIT = "WindowLimit";
-//  private static final String TEST_DATA_SERVICE_NAME = "dataservice_test";
-//  private static final String TEST_SQL_QUERY = "SELECT * FROM dataservice_test";
-//  private static final String TEST_LARGE_SQL_QUERY = TEST_SQL_QUERY + " /" + StringUtils.repeat( "*", 8000 ) + "/";
-//  private static final String DEBUG_TRANS_FILE = "debugtransfile";
-//  private static final String TEST_MAX_ROWS = "100";
-//  private static final String TEST_WINDOW_MODE_ROW = IDataServiceClientService.StreamingMode.ROW_BASED.toString();
-//  private static final String TEST_WINDOW_MODE_TIME = IDataServiceClientService.StreamingMode.TIME_BASED.toString();
-//  private static final String TEST_WINDOW_SIZE = "1";
-//  private static final String TEST_WINDOW_EVERY = "2";
-//  private static final String TEST_WINDOW_LIMIT = "3";
-//  private static final String PARAM_DEBUG_TRANS = "debugtrans";
-//  private static final String SERVLET_STRING = "Get data from a data service";
-//  private static final String serviceTransUUID = UUID.randomUUID().toString();
-//  private static final String genTransUUID = UUID.randomUUID().toString();
-//  private static final String GEN_TRANS_XML = "<trans name=genTrans mock/>";
-//
-//  private static final int DEFAULT_WINDOW_MAX_ROWS = 50;
-//  private static final long DEFAULT_WINDOW_MAX_TIME = 1000;
-//
-//  @Rule public TemporaryFolder fs = new TemporaryFolder();
-//
-//  private Trans serviceTrans;
-//
-//  private TransMeta genTransMeta;
-//
-//  private Trans genTrans;
-//
-//  private TransDataServlet servlet;
-//
-//  private File debugTrans;
-//
-//  @Before
-//  public void setUp() throws Exception {
-////    when( context.getLogChannel() ).thenReturn( log );
-//    serviceTrans = new Trans( transMeta );
-//    serviceTrans.setContainerObjectId( serviceTransUUID );
-//    genTransMeta = createTransMeta( TEST_SQL_QUERY );
-//    genTrans = new Trans( genTransMeta );
-//    genTrans.setContainerObjectId( genTransUUID );
-//
-//    doReturn( GEN_TRANS_XML ).when( genTransMeta ).getXML();
-//
-//    servlet = new TransDataServlet( client );
-//    servlet.setJettyMode( true );
-//    servlet.setup( transformationMap, null, null, null );
-//
-//    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
-//    debugTrans = fs.newFile( DEBUG_TRANS_FILE );
-//  }
-//
-//  @Test
-//  public void testDoPut() throws Exception {
-//    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-//    parameters.put( "PARAMETER_FOO", "BAR" );
-//    parameters.put( PARAM_DEBUG_TRANS, debugTrans.getPath() );
-//
-//    Query query = mock( Query.class );
-//    doReturn( query )
-//      .when( client )
-//      .prepareQuery( TEST_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.of( "FOO", "BAR" ) );
-//    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//
-////    when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//
-//    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
-//    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
-//    verify( request, never() ).getParameter( HEADER_WINDOW_MODE );
-//    verify( request, never() ).getParameter( HEADER_WINDOW_SIZE );
-//    verify( request, never() ).getParameter( HEADER_WINDOW_EVERY );
-//    verify( request, never() ).getParameter( HEADER_WINDOW_LIMIT );
-//
-//    verify( response ).setStatus( HttpServletResponse.SC_OK );
-//    verify( response ).setContentType( "binary/jdbc" );
-//    verify( query ).writeTo( outputStream );
-//
-//    verify( transformationMap ).addTransformation(
-//      eq( DATA_SERVICE_NAME ),
-//      eq( serviceTransUUID ),
-//      eq( serviceTrans ),
-//      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( transMeta ) ) )
-//    );
-//    verify( transformationMap ).addTransformation(
-//      eq( TEST_SQL_QUERY ),
-//      eq( genTransUUID ),
-//      eq( genTrans ),
-//      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( genTransMeta ) ) )
-//    );
-//    Files.readLines( debugTrans, Charsets.UTF_8 ).contains( GEN_TRANS_XML );
-//  }
-//
-//  @Test
-//  public void testStreamingHeader() throws Exception {
-//    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-//    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
-//    headers.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
-//    headers.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
-//    headers.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
-//
-//    Query query = mock( Query.class );
-//    lenient().doReturn( query )
-//      .when( client )
-//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
-//        Long.valueOf( TEST_WINDOW_SIZE ),
-//        Long.valueOf( TEST_WINDOW_EVERY ),
-//        Long.valueOf( TEST_WINDOW_LIMIT ),
-//        ImmutableMap.of( "FOO", "BAR" ) );
-//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-//
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//
-//    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
-//    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
-//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_MODE );
-//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_SIZE );
-//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_EVERY );
-//    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_LIMIT );
-//    verify( request, times( 1 ) ).getHeader( HEADER_SQL );
-//    verify( request, times( 1 ) ).getHeader( HEADER_MAX_ROWS );
-//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_MODE );
-//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_SIZE );
-//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_EVERY );
-//    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_LIMIT );
-//  }
-//
-//  @Test
-//  public void testStreamingParameters() throws Exception {
-//    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-//    parameters.put( HEADER_SQL, TEST_SQL_QUERY );
-//    parameters.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
-//    parameters.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
-//    parameters.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
-//    parameters.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
-//
-//    Query query = mock( Query.class );
-//    lenient().doReturn( query )
-//      .when( client )
-//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
-//        Long.valueOf( TEST_WINDOW_SIZE ),
-//        Long.valueOf( TEST_WINDOW_EVERY ),
-//        Long.valueOf( TEST_WINDOW_LIMIT ),
-//        ImmutableMap.of( "FOO", "BAR" ) );
-//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-//
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//
-//    verify( request, times( 2 ) ).getParameter( HEADER_SQL );
-//    verify( request, times( 2 ) ).getParameter( HEADER_MAX_ROWS );
-//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_MODE );
-//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_SIZE );
-//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_EVERY );
-//    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_LIMIT );
-//    verify( request, never() ).getHeader( HEADER_SQL );
-//    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
-//    verify( request, never() ).getHeader( HEADER_WINDOW_MODE );
-//    verify( request, never() ).getHeader( HEADER_WINDOW_SIZE );
-//    verify( request, never() ).getHeader( HEADER_WINDOW_EVERY );
-//    verify( request, never() ).getHeader( HEADER_WINDOW_LIMIT );
-//  }
-//
-//  @Test
-//  public void testStreamingRowBasedDefaultParams() throws Exception {
-//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-//    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_ROW );
-//
-//    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
-//    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
-//
-//    Query query = mock( Query.class );
-//    lenient().doReturn( query )
-//      .when( client )
-//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
-//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-//        ImmutableMap.of( "FOO", "BAR" ) );
-//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-//
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//  }
-//
-//  @Test
-//  public void testStreamingDefaultModeDefauldParams() throws Exception {
-//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-//
-//    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
-//    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
-//
-//    Query query = mock( Query.class );
-//    lenient().doReturn( query )
-//      .when( client )
-//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
-//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-//        ImmutableMap.of( "FOO", "BAR" ) );
-//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-//
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//  }
-//
-//  @Test
-//  public void testStreamingTimeBasedModeDefauldParams() throws Exception {
-//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-//    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
-//
-//    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
-//    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
-//
-//    Query query = mock( Query.class );
-//    lenient().doReturn( query )
-//      .when( client )
-//      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
-//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-//        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
-//        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
-//        ImmutableMap.of( "FOO", "BAR" ) );
-//    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
-//
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//  }
-//
-//  @Test
-//  public void testLargeSQLQuery() throws Exception {
-//    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
-//    parameters.put( HEADER_SQL, TEST_LARGE_SQL_QUERY );
-//
-//    Query query = mock( Query.class );
-//    doReturn( query )
-//        .when( client )
-//        .prepareQuery( TEST_LARGE_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.<String, String>of() );
-//    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
-//
-//    lenient().when( request.getMethod() ).thenReturn( "POST" );
-//    servlet.service( request, response );
-//    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
-//
-//    verify( request, never() ).getHeader( HEADER_SQL );
-//    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
-//  }
-//
-//  @Test
-//  public void testMultipleParamValues() throws IOException, ServletException {
-//    parameters.put( "PARAMETER_foo", "bar" );
-//    parameters.put( "PARAMETER_foo", "baz" );
-//    parameters.put( "SQL", "select * from dual" );
-//    servlet.service( request, response );
-//    ArgumentCaptor<String> captor = ArgumentCaptor.forClass( String.class );
-//    verify( log ).logDetailed( captor.capture() );
-//    assertThat( captor.getValue(), containsString( "PARAMETER_foo" ) );
-//  }
-//
-//  @Test
-//  public void testDoGetException() throws Exception {
-//    lenient().when( factory.createBuilder( any( SQL.class ) ) ).thenThrow( new MetaStoreException( "expected" ) );
-//
-//    headers.put( HEADER_SQL, TEST_SQL_QUERY );
-//    servlet.service( request, response );
-//
-//    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
-//  }
-//
-//  @Test
-//  public void testDoGetMissingSQL() throws Exception {
-//    headers.removeAll( HEADER_SQL );
-//    servlet.service( request, response );
-//
-//    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
-//    verify( client, times( 1 ) ).getLogChannel();
-//  }
-//
-//  @Test
-//  public void testDoGetBadPath() throws Exception {
-//    when( request.getContextPath() ).thenReturn( BAD_CONTEXT_PATH );
-//
-//    servlet.service( request, response );
-//
-//    verify( response, never() ).setStatus( HttpServletResponse.SC_OK );
-//  }
-//
-//  @Test
-//  public void testToString() {
-//    assertEquals( SERVLET_STRING, servlet.toString() );
-//  }
-//
-//  @Test
-//  public void testGetService() {
-//    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
-//  }
-//
-//  @Test
-//  public void testGetContextPath() {
-//    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
-//  }
-//}
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.di.trans.dataservice.www;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.hamcrest.MockitoHamcrest;
+import org.pentaho.di.core.sql.SQL;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransConfiguration;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.dataservice.client.api.IDataServiceClientService;
+import org.pentaho.di.trans.dataservice.clients.Query;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author bmorrise nhudak
+ */
+public class TransDataServletTest extends BaseServletTest {
+
+  private static final String BAD_CONTEXT_PATH = "/badsql";
+  private static final String CONTEXT_PATH = "/sql";
+  private static final String HEADER_SQL = "SQL";
+  private static final String HEADER_MAX_ROWS = "MaxRows";
+  private static final String HEADER_WINDOW_MODE = "WindowMode";
+  private static final String HEADER_WINDOW_SIZE = "WindowSize";
+  private static final String HEADER_WINDOW_EVERY = "WindowEvery";
+  private static final String HEADER_WINDOW_LIMIT = "WindowLimit";
+  private static final String TEST_DATA_SERVICE_NAME = "dataservice_test";
+  private static final String TEST_SQL_QUERY = "SELECT * FROM dataservice_test";
+  private static final String TEST_LARGE_SQL_QUERY = TEST_SQL_QUERY + " /" + StringUtils.repeat( "*", 8000 ) + "/";
+  private static final String DEBUG_TRANS_FILE = "debugtransfile";
+  private static final String TEST_MAX_ROWS = "100";
+  private static final String TEST_WINDOW_MODE_ROW = IDataServiceClientService.StreamingMode.ROW_BASED.toString();
+  private static final String TEST_WINDOW_MODE_TIME = IDataServiceClientService.StreamingMode.TIME_BASED.toString();
+  private static final String TEST_WINDOW_SIZE = "1";
+  private static final String TEST_WINDOW_EVERY = "2";
+  private static final String TEST_WINDOW_LIMIT = "3";
+  private static final String PARAM_DEBUG_TRANS = "debugtrans";
+  private static final String SERVLET_STRING = "Get data from a data service";
+  private static final String serviceTransUUID = UUID.randomUUID().toString();
+  private static final String genTransUUID = UUID.randomUUID().toString();
+  private static final String GEN_TRANS_XML = "<trans name=genTrans mock/>";
+
+  private static final int DEFAULT_WINDOW_MAX_ROWS = 50;
+  private static final long DEFAULT_WINDOW_MAX_TIME = 1000;
+
+  @Rule public TemporaryFolder fs = new TemporaryFolder();
+
+  private Trans serviceTrans;
+
+  private TransMeta genTransMeta;
+
+  private Trans genTrans;
+
+  private TransDataServlet servlet;
+
+  private File debugTrans;
+
+  @Before
+  public void setUp() throws Exception {
+//    when( context.getLogChannel() ).thenReturn( log );
+    serviceTrans = new Trans( transMeta );
+    serviceTrans.setContainerObjectId( serviceTransUUID );
+    genTransMeta = createTransMeta( TEST_SQL_QUERY );
+    genTrans = new Trans( genTransMeta );
+    genTrans.setContainerObjectId( genTransUUID );
+
+    doReturn( GEN_TRANS_XML ).when( genTransMeta ).getXML();
+
+    servlet = new TransDataServlet( client );
+    servlet.setJettyMode( true );
+    servlet.setup( transformationMap, null, null, null );
+
+    when( request.getContextPath() ).thenReturn( CONTEXT_PATH );
+    debugTrans = fs.newFile( DEBUG_TRANS_FILE );
+  }
+
+  @Test
+  public void testDoPut() throws Exception {
+    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+    parameters.put( "PARAMETER_FOO", "BAR" );
+    parameters.put( PARAM_DEBUG_TRANS, debugTrans.getPath() );
+
+    Query query = mock( Query.class );
+    doReturn( query )
+      .when( client )
+      .prepareQuery( TEST_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.of( "FOO", "BAR" ) );
+    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+
+//    when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+
+    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
+    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
+    verify( request, never() ).getParameter( HEADER_WINDOW_MODE );
+    verify( request, never() ).getParameter( HEADER_WINDOW_SIZE );
+    verify( request, never() ).getParameter( HEADER_WINDOW_EVERY );
+    verify( request, never() ).getParameter( HEADER_WINDOW_LIMIT );
+
+    verify( response ).setStatus( HttpServletResponse.SC_OK );
+    verify( response ).setContentType( "binary/jdbc" );
+    verify( query ).writeTo( outputStream );
+
+    verify( transformationMap ).addTransformation(
+      eq( DATA_SERVICE_NAME ),
+      eq( serviceTransUUID ),
+      eq( serviceTrans ),
+      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( transMeta ) ) )
+    );
+    verify( transformationMap ).addTransformation(
+      eq( TEST_SQL_QUERY ),
+      eq( genTransUUID ),
+      eq( genTrans ),
+      (TransConfiguration) MockitoHamcrest.argThat( hasProperty( "transMeta", is( genTransMeta ) ) )
+    );
+    Files.readLines( debugTrans, Charsets.UTF_8 ).contains( GEN_TRANS_XML );
+  }
+
+  @Test
+  public void testStreamingHeader() throws Exception {
+    headers.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
+    headers.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
+    headers.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
+    headers.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
+
+    Query query = mock( Query.class );
+    lenient().doReturn( query )
+      .when( client )
+      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
+        Long.valueOf( TEST_WINDOW_SIZE ),
+        Long.valueOf( TEST_WINDOW_EVERY ),
+        Long.valueOf( TEST_WINDOW_LIMIT ),
+        ImmutableMap.of( "FOO", "BAR" ) );
+    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+
+    verify( request, times( 1 ) ).getParameter( HEADER_SQL );
+    verify( request, times( 1 ) ).getParameter( HEADER_MAX_ROWS );
+    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_MODE );
+    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_SIZE );
+    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_EVERY );
+    verify( request, times( 1 ) ).getParameter( HEADER_WINDOW_LIMIT );
+    verify( request, times( 1 ) ).getHeader( HEADER_SQL );
+    verify( request, times( 1 ) ).getHeader( HEADER_MAX_ROWS );
+    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_MODE );
+    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_SIZE );
+    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_EVERY );
+    verify( request, times( 1 ) ).getHeader( HEADER_WINDOW_LIMIT );
+  }
+
+  @Test
+  public void testStreamingParameters() throws Exception {
+    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+    parameters.put( HEADER_SQL, TEST_SQL_QUERY );
+    parameters.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
+    parameters.put( HEADER_WINDOW_SIZE, TEST_WINDOW_SIZE );
+    parameters.put( HEADER_WINDOW_EVERY, TEST_WINDOW_EVERY );
+    parameters.put( HEADER_WINDOW_LIMIT, TEST_WINDOW_LIMIT );
+
+    Query query = mock( Query.class );
+    lenient().doReturn( query )
+      .when( client )
+      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
+        Long.valueOf( TEST_WINDOW_SIZE ),
+        Long.valueOf( TEST_WINDOW_EVERY ),
+        Long.valueOf( TEST_WINDOW_LIMIT ),
+        ImmutableMap.of( "FOO", "BAR" ) );
+    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+
+    verify( request, times( 2 ) ).getParameter( HEADER_SQL );
+    verify( request, times( 2 ) ).getParameter( HEADER_MAX_ROWS );
+    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_MODE );
+    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_SIZE );
+    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_EVERY );
+    verify( request, times( 2 ) ).getParameter( HEADER_WINDOW_LIMIT );
+    verify( request, never() ).getHeader( HEADER_SQL );
+    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
+    verify( request, never() ).getHeader( HEADER_WINDOW_MODE );
+    verify( request, never() ).getHeader( HEADER_WINDOW_SIZE );
+    verify( request, never() ).getHeader( HEADER_WINDOW_EVERY );
+    verify( request, never() ).getHeader( HEADER_WINDOW_LIMIT );
+  }
+
+  @Test
+  public void testStreamingRowBasedDefaultParams() throws Exception {
+    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_ROW );
+
+    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
+    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
+
+    Query query = mock( Query.class );
+    lenient().doReturn( query )
+      .when( client )
+      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
+        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+        ImmutableMap.of( "FOO", "BAR" ) );
+    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+  }
+
+  @Test
+  public void testStreamingDefaultModeDefauldParams() throws Exception {
+    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+
+    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
+    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
+
+    Query query = mock( Query.class );
+    lenient().doReturn( query )
+      .when( client )
+      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.ROW_BASED,
+        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+        ImmutableMap.of( "FOO", "BAR" ) );
+    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+  }
+
+  @Test
+  public void testStreamingTimeBasedModeDefauldParams() throws Exception {
+    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+    headers.put( HEADER_WINDOW_MODE, TEST_WINDOW_MODE_TIME );
+
+    streamingDataService.setTimeLimit( DEFAULT_WINDOW_MAX_TIME );
+    streamingDataService.setRowLimit( DEFAULT_WINDOW_MAX_ROWS );
+
+    Query query = mock( Query.class );
+    lenient().doReturn( query )
+      .when( client )
+      .prepareQuery( TEST_SQL_QUERY, IDataServiceClientService.StreamingMode.TIME_BASED,
+        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+        Long.valueOf( DEFAULT_WINDOW_MAX_TIME ),
+        Long.valueOf( DEFAULT_WINDOW_MAX_ROWS ),
+        ImmutableMap.of( "FOO", "BAR" ) );
+    lenient().when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+    when( client.getServiceMeta( TEST_DATA_SERVICE_NAME ) ).thenReturn( streamingDataService );
+
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+  }
+
+  @Test
+  public void testLargeSQLQuery() throws Exception {
+    parameters.put( HEADER_MAX_ROWS, TEST_MAX_ROWS );
+    parameters.put( HEADER_SQL, TEST_LARGE_SQL_QUERY );
+
+    Query query = mock( Query.class );
+    doReturn( query )
+        .when( client )
+        .prepareQuery( TEST_LARGE_SQL_QUERY, Integer.valueOf( TEST_MAX_ROWS ), ImmutableMap.<String, String>of() );
+    when( query.getTransList() ).thenReturn( ImmutableList.of( serviceTrans, genTrans ) );
+
+    lenient().when( request.getMethod() ).thenReturn( "POST" );
+    servlet.service( request, response );
+    verify( logChannel, never() ).logError( anyString(), (Throwable) any() );
+
+    verify( request, never() ).getHeader( HEADER_SQL );
+    verify( request, never() ).getHeader( HEADER_MAX_ROWS );
+  }
+
+  @Test
+  public void testMultipleParamValues() throws IOException, ServletException {
+    parameters.put( "PARAMETER_foo", "bar" );
+    parameters.put( "PARAMETER_foo", "baz" );
+    parameters.put( "SQL", "select * from dual" );
+    servlet.service( request, response );
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass( String.class );
+    verify( log ).logDetailed( captor.capture() );
+    assertThat( captor.getValue(), containsString( "PARAMETER_foo" ) );
+  }
+
+  @Test
+  public void testDoGetException() throws Exception {
+    lenient().when( factory.createBuilder( any( SQL.class ) ) ).thenThrow( new MetaStoreException( "expected" ) );
+
+    headers.put( HEADER_SQL, TEST_SQL_QUERY );
+    servlet.service( request, response );
+
+    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
+  }
+
+  @Test
+  public void testDoGetMissingSQL() throws Exception {
+    headers.removeAll( HEADER_SQL );
+    servlet.service( request, response );
+
+    verify( response ).sendError( HttpServletResponse.SC_BAD_REQUEST );
+    verify( client, times( 1 ) ).getLogChannel();
+  }
+
+  @Test
+  public void testDoGetBadPath() throws Exception {
+    when( request.getContextPath() ).thenReturn( BAD_CONTEXT_PATH );
+
+    servlet.service( request, response );
+
+    verify( response, never() ).setStatus( HttpServletResponse.SC_OK );
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals( SERVLET_STRING, servlet.toString() );
+  }
+
+  @Test
+  public void testGetService() {
+    assertEquals( CONTEXT_PATH + " (" + SERVLET_STRING + ")", servlet.getService() );
+  }
+
+  @Test
+  public void testGetContextPath() {
+    assertEquals( CONTEXT_PATH, servlet.getContextPath() );
+  }
+}


### PR DESCRIPTION
This pull request includes updates to test files in the `impl/src/test/java/org/pentaho/di/trans/dataservice` directory to address race conditions in multithreaded tests, ensure compatibility with the `jakarta.servlet` package, and improve assertions in controller tests.

### Race condition fixes in multithreaded tests:
* Added `Thread.sleep(2000)` in multiple test methods (`testWriteFailure`, `testWindowQueryWriteFailure`, `testInputStreamClosed`, `testWindowInputStreamClosed`) to prevent race conditions between the main thread and executor service threads. Updated `logError` verification to use `isNull()` for null argument matching. (`[[1]](diffhunk://#diff-9890648be827cb7ba56eb583629b3f3b960934329cb44a15aa160001134692d3L185-R188)`, `[[2]](diffhunk://#diff-9890648be827cb7ba56eb583629b3f3b960934329cb44a15aa160001134692d3L201-R206)`, `[[3]](diffhunk://#diff-9890648be827cb7ba56eb583629b3f3b960934329cb44a15aa160001134692d3R266-R267)`, `[[4]](diffhunk://#diff-9890648be827cb7ba56eb583629b3f3b960934329cb44a15aa160001134692d3R298-R299)`)

### Migration to `jakarta.servlet` package:
* Replaced imports of `javax.servlet` classes with `jakarta.servlet` equivalents in test files (`BaseServletTest`, `ListDataServicesServletTest`, `TransDataServletTest`) to ensure compatibility with the updated servlet API. (`[[1]](diffhunk://#diff-6385ad2ab1ccfc53e66a1d49e25328acf9edce29d706b0743b63adad17e2a232L34-R36)`, `[[2]](diffhunk://#diff-f6210ab3667e824e4a8178b434895e0b5a513fdcddd04cf2c11cf7ab174af535L25-R25)`, `[[3]](diffhunk://#diff-9127f9ef7a1930d8554d1875bccff54ab59a1b0bbbff48cc3043983b8e41ff79L35-R36)`)

### Assertion improvement in controller tests:
* Updated `Assert.hasText` in `testController` to include an explicit default value for the text parameter. (`[impl/src/test/java/org/pentaho/di/trans/dataservice/ui/controller/DataServiceRemapNoStepsDialogControllerTest.javaL32-R32](diffhunk://#diff-0f061e76768c5b7fa3c1eee0b63560ba1f0e18e8a2f4ff297c9f0ab527b2d826L32-R32)`)